### PR TITLE
refactor: encapsulate RouteGenerator within RouteService

### DIFF
--- a/src/gui/components/buttons.rs
+++ b/src/gui/components/buttons.rs
@@ -7,6 +7,7 @@ use crate::{
     gui::services::{RouteService, ValidationService},
     gui::state::popup_state::DisplayMode,
     gui::ui::Gui,
+    modules::routes::GENERATE_AMOUNT,
 };
 
 impl Gui<'_> {
@@ -57,7 +58,9 @@ impl Gui<'_> {
         if ui.button("Get random airports").clicked() {
             self.reset_and_set_display_mode(DisplayMode::RandomAirports);
 
-            let airports = self.get_route_service().generate_random_airports(50);
+            let airports = self
+                .get_route_service()
+                .generate_random_airports(GENERATE_AMOUNT);
 
             self.set_displayed_items(airports);
             self.reset_ui_state_and_refresh(true);

--- a/src/gui/components/buttons.rs
+++ b/src/gui/components/buttons.rs
@@ -163,11 +163,9 @@ impl Gui<'_> {
         let departure_icao = self.get_departure_icao_for_routes();
         let all_aircraft = self.get_all_aircraft().to_vec(); // Clone to avoid borrowing conflict
 
-        let routes = RouteService::generate_random_routes(
-            self.get_route_generator(),
-            &all_aircraft,
-            departure_icao,
-        );
+        let routes = self
+            .get_route_service()
+            .generate_random_routes(&all_aircraft, departure_icao);
 
         self.extend_displayed_items(routes);
         self.reset_ui_state_and_refresh(false);
@@ -182,11 +180,9 @@ impl Gui<'_> {
         let departure_icao = self.get_departure_icao_for_routes();
         let all_aircraft = self.get_all_aircraft().to_vec(); // Clone to avoid borrowing conflict
 
-        let routes = RouteService::generate_not_flown_routes(
-            self.get_route_generator(),
-            &all_aircraft,
-            departure_icao,
-        );
+        let routes = self
+            .get_route_service()
+            .generate_not_flown_routes(&all_aircraft, departure_icao);
 
         self.extend_displayed_items(routes);
         self.reset_ui_state_and_refresh(false);
@@ -330,14 +326,10 @@ impl Gui<'_> {
         let departure_icao = self.get_departure_icao_for_routes();
 
         let routes = self
-            .get_route_generator()
+            .get_route_service()
             .generate_routes_for_aircraft(aircraft, departure_icao);
 
-        self.extend_displayed_items(
-            routes
-                .into_iter()
-                .map(|route| Arc::new(TableItem::Route(route))),
-        );
+        self.extend_displayed_items(routes);
         self.handle_search();
     }
 }

--- a/src/gui/components/buttons.rs
+++ b/src/gui/components/buttons.rs
@@ -4,7 +4,6 @@ use egui::Ui;
 use rand::prelude::*;
 
 use crate::{
-    gui::data::{ListItemAirport, TableItem},
     gui::services::{RouteService, ValidationService},
     gui::ui::Gui,
 };
@@ -54,17 +53,16 @@ impl Gui<'_> {
             }
         }
 
-        if ui.button("Get random airport").clicked() {
-            if let Some(airport) = self.get_available_airports().choose(&mut rand::rng()) {
-                let airport_item = Arc::new(TableItem::Airport(ListItemAirport::new(
-                    airport.ID.to_string(),
-                    airport.Name.clone(),
-                    airport.ICAO.clone(),
-                )));
+        if ui.button("Get random airports").clicked() {
+            self.clear_displayed_items();
+            self.set_routes_from_not_flown(false);
+            self.set_routes_for_specific_aircraft(false);
+            self.set_airports_random(true);
 
-                self.set_displayed_items(vec![airport_item]);
-                self.reset_ui_state_and_refresh(true);
-            }
+            let airports = self.get_route_service().generate_random_airports(50);
+
+            self.set_displayed_items(airports);
+            self.reset_ui_state_and_refresh(true);
         }
     }
 
@@ -75,6 +73,11 @@ impl Gui<'_> {
     /// * `ui` - The UI context.
     fn render_list_buttons(&mut self, ui: &mut Ui) {
         if ui.button("List all airports").clicked() {
+            self.clear_displayed_items();
+            self.set_routes_from_not_flown(false);
+            self.set_routes_for_specific_aircraft(false);
+            self.set_airports_random(false);
+
             let airports = self.get_available_airports().to_vec(); // Clone to avoid borrowing conflict
             let displayed_items = RouteService::load_airport_items(&airports);
             self.set_displayed_items(displayed_items);
@@ -82,6 +85,11 @@ impl Gui<'_> {
         }
 
         if ui.button("List history").clicked() {
+            self.clear_displayed_items();
+            self.set_routes_from_not_flown(false);
+            self.set_routes_for_specific_aircraft(false);
+            self.set_airports_random(false);
+
             let all_aircraft = self.get_all_aircraft().to_vec(); // Clone to avoid borrowing conflict
             match RouteService::load_history_items(self.get_database_pool(), &all_aircraft) {
                 Ok(displayed_items) => {
@@ -159,6 +167,7 @@ impl Gui<'_> {
         self.clear_displayed_items();
         self.set_routes_from_not_flown(false);
         self.set_routes_for_specific_aircraft(false);
+        self.set_airports_random(false);
 
         let departure_icao = self.get_departure_icao_for_routes();
         let all_aircraft = self.get_all_aircraft().to_vec(); // Clone to avoid borrowing conflict
@@ -176,6 +185,7 @@ impl Gui<'_> {
         self.clear_displayed_items();
         self.set_routes_from_not_flown(true);
         self.set_routes_for_specific_aircraft(false);
+        self.set_airports_random(false);
 
         let departure_icao = self.get_departure_icao_for_routes();
         let all_aircraft = self.get_all_aircraft().to_vec(); // Clone to avoid borrowing conflict
@@ -322,6 +332,7 @@ impl Gui<'_> {
         self.clear_displayed_items();
         self.set_routes_from_not_flown(false);
         self.set_routes_for_specific_aircraft(true);
+        self.set_airports_random(false);
 
         let departure_icao = self.get_departure_icao_for_routes();
 

--- a/src/gui/components/buttons.rs
+++ b/src/gui/components/buttons.rs
@@ -5,6 +5,7 @@ use rand::prelude::*;
 
 use crate::{
     gui::services::{RouteService, ValidationService},
+    gui::state::popup_state::DisplayMode,
     gui::ui::Gui,
 };
 
@@ -54,10 +55,7 @@ impl Gui<'_> {
         }
 
         if ui.button("Get random airports").clicked() {
-            self.clear_displayed_items();
-            self.set_routes_from_not_flown(false);
-            self.set_routes_for_specific_aircraft(false);
-            self.set_airports_random(true);
+            self.reset_and_set_display_mode(DisplayMode::RandomAirports);
 
             let airports = self.get_route_service().generate_random_airports(50);
 
@@ -73,10 +71,7 @@ impl Gui<'_> {
     /// * `ui` - The UI context.
     fn render_list_buttons(&mut self, ui: &mut Ui) {
         if ui.button("List all airports").clicked() {
-            self.clear_displayed_items();
-            self.set_routes_from_not_flown(false);
-            self.set_routes_for_specific_aircraft(false);
-            self.set_airports_random(false);
+            self.reset_and_set_display_mode(DisplayMode::Other);
 
             let airports = self.get_available_airports().to_vec(); // Clone to avoid borrowing conflict
             let displayed_items = RouteService::load_airport_items(&airports);
@@ -85,10 +80,7 @@ impl Gui<'_> {
         }
 
         if ui.button("List history").clicked() {
-            self.clear_displayed_items();
-            self.set_routes_from_not_flown(false);
-            self.set_routes_for_specific_aircraft(false);
-            self.set_airports_random(false);
+            self.reset_and_set_display_mode(DisplayMode::Other);
 
             let all_aircraft = self.get_all_aircraft().to_vec(); // Clone to avoid borrowing conflict
             match RouteService::load_history_items(self.get_database_pool(), &all_aircraft) {
@@ -162,12 +154,16 @@ impl Gui<'_> {
         }
     }
 
+    /// Helper method to reset display state and set specific display mode.
+    /// This provides a type-safe way to set the display mode using an enum.
+    fn reset_and_set_display_mode(&mut self, mode: DisplayMode) {
+        self.clear_displayed_items();
+        self.set_display_mode(mode);
+    }
+
     /// Generates random routes using encapsulated state.
     fn generate_random_routes(&mut self) {
-        self.clear_displayed_items();
-        self.set_routes_from_not_flown(false);
-        self.set_routes_for_specific_aircraft(false);
-        self.set_airports_random(false);
+        self.reset_and_set_display_mode(DisplayMode::RandomRoutes);
 
         let departure_icao = self.get_departure_icao_for_routes();
         let all_aircraft = self.get_all_aircraft().to_vec(); // Clone to avoid borrowing conflict
@@ -182,10 +178,7 @@ impl Gui<'_> {
 
     /// Generates routes for not flown aircraft using encapsulated state.
     fn generate_not_flown_routes(&mut self) {
-        self.clear_displayed_items();
-        self.set_routes_from_not_flown(true);
-        self.set_routes_for_specific_aircraft(false);
-        self.set_airports_random(false);
+        self.reset_and_set_display_mode(DisplayMode::NotFlownRoutes);
 
         let departure_icao = self.get_departure_icao_for_routes();
         let all_aircraft = self.get_all_aircraft().to_vec(); // Clone to avoid borrowing conflict
@@ -329,10 +322,7 @@ impl Gui<'_> {
     ///
     /// * `aircraft` - The selected aircraft.
     fn generate_routes_for_selected_aircraft(&mut self, aircraft: &Arc<crate::models::Aircraft>) {
-        self.clear_displayed_items();
-        self.set_routes_from_not_flown(false);
-        self.set_routes_for_specific_aircraft(true);
-        self.set_airports_random(false);
+        self.reset_and_set_display_mode(DisplayMode::SpecificAircraftRoutes);
 
         let departure_icao = self.get_departure_icao_for_routes();
 

--- a/src/gui/components/table.rs
+++ b/src/gui/components/table.rs
@@ -88,7 +88,7 @@ impl Gui<'_> {
                         });
                     }
 
-                    // Handle route-specific columns
+                    // Handle route-specific columns and infinite loading
                     if let TableItem::Route(route) = item.as_ref() {
                         // Trigger loading more routes when we reach the last visible row
                         if row.index() == filtered_items.len() - 1 {
@@ -100,6 +100,11 @@ impl Gui<'_> {
                                 selected_route = Some(route.clone());
                             }
                         });
+                    } else if matches!(item.as_ref(), TableItem::Airport(_)) {
+                        // Trigger loading more airports when we reach the last visible row
+                        if row.index() == filtered_items.len() - 1 {
+                            create_more_routes = true;
+                        }
                     }
                 });
 
@@ -110,7 +115,7 @@ impl Gui<'_> {
                 }
             });
 
-        // Load more routes if we've reached the end and it's a route table using encapsulated state
+        // Load more items if we've reached the end and it's not a search using encapsulated state
         if create_more_routes && self.get_search_query().is_empty() {
             self.load_more_routes_if_needed();
         }

--- a/src/gui/data/list_items.rs
+++ b/src/gui/data/list_items.rs
@@ -89,17 +89,21 @@ impl ListItemAircraft {
 /// A structure representing an airport list item.
 #[derive(Clone)]
 pub struct ListItemAirport {
-    /// The ID of the airport.
-    pub id: String,
     /// The name of the airport.
     pub name: String,
     /// The ICAO code of the airport.
     pub icao: String,
+    /// The longest runway length in feet.
+    pub longest_runway_length: String,
 }
 
 impl ListItemAirport {
     /// Creates a new airport list item.
-    pub const fn new(id: String, name: String, icao: String) -> Self {
-        Self { id, name, icao }
+    pub const fn new(name: String, icao: String, longest_runway_length: String) -> Self {
+        Self {
+            name,
+            icao,
+            longest_runway_length,
+        }
     }
 }

--- a/src/gui/data/table_items.rs
+++ b/src/gui/data/table_items.rs
@@ -17,7 +17,7 @@ impl TableItem {
     /// Returns the column headers for the table item.
     pub fn get_columns(&self) -> Vec<&'static str> {
         match self {
-            Self::Airport(_) => vec!["ID", "Name", "ICAO"],
+            Self::Airport(_) => vec!["Name", "ICAO", "Longest Runway"],
             Self::Aircraft(_) => vec!["ID", "Model", "Registration", "Flown"],
             Self::Route(_) => vec![
                 "Departure",
@@ -38,9 +38,9 @@ impl TableItem {
     pub fn get_data(&self) -> Vec<Cow<'_, str>> {
         match self {
             Self::Airport(airport) => vec![
-                Cow::Borrowed(&airport.id),
                 Cow::Borrowed(&airport.name),
                 Cow::Borrowed(&airport.icao),
+                Cow::Borrowed(&airport.longest_runway_length),
             ],
             Self::Aircraft(aircraft) => vec![
                 Cow::Borrowed(aircraft.get_id()),
@@ -84,7 +84,10 @@ impl TableItem {
             Self::Airport(airport) => {
                 airport.name.to_lowercase().contains(&query)
                     || airport.icao.to_lowercase().contains(&query)
-                    || airport.id.to_string().contains(&query)
+                    || airport
+                        .longest_runway_length
+                        .to_lowercase()
+                        .contains(&query)
             }
             Self::Aircraft(aircraft) => {
                 aircraft.get_variant().to_lowercase().contains(&query)

--- a/src/gui/services/route_service.rs
+++ b/src/gui/services/route_service.rs
@@ -37,6 +37,22 @@ impl RouteService {
         &self.route_generator.all_airports
     }
 
+    /// Converts a vector of routes into a vector of route table items.
+    ///
+    /// # Arguments
+    ///
+    /// * `routes` - The routes to convert
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of route table items wrapped in Arc.
+    fn wrap_routes_as_table_items(routes: Vec<ListItemRoute>) -> Vec<Arc<TableItem>> {
+        routes
+            .into_iter()
+            .map(|route| Arc::new(TableItem::Route(route)))
+            .collect()
+    }
+
     /// Generates random routes for all aircraft.
     ///
     /// # Arguments
@@ -55,10 +71,7 @@ impl RouteService {
         let routes = self
             .route_generator
             .generate_random_routes(aircraft, departure_icao);
-        routes
-            .into_iter()
-            .map(|route| Arc::new(TableItem::Route(route)))
-            .collect()
+        Self::wrap_routes_as_table_items(routes)
     }
 
     /// Generates routes for not flown aircraft.
@@ -79,10 +92,7 @@ impl RouteService {
         let routes = self
             .route_generator
             .generate_random_not_flown_aircraft_routes(aircraft, departure_icao);
-        routes
-            .into_iter()
-            .map(|route| Arc::new(TableItem::Route(route)))
-            .collect()
+        Self::wrap_routes_as_table_items(routes)
     }
 
     /// Generates routes for a specific aircraft.
@@ -103,10 +113,7 @@ impl RouteService {
         let routes = self
             .route_generator
             .generate_routes_for_aircraft(aircraft, departure_icao);
-        routes
-            .into_iter()
-            .map(|route| Arc::new(TableItem::Route(route)))
-            .collect()
+        Self::wrap_routes_as_table_items(routes)
     }
 
     /// Marks a route as flown in the database and updates the aircraft.

--- a/src/gui/services/route_service.rs
+++ b/src/gui/services/route_service.rs
@@ -15,7 +15,7 @@ pub struct RouteService {
 }
 
 impl RouteService {
-    /// Creates a new RouteService with the given RouteGenerator.
+    /// Creates a new `RouteService` with the given `RouteGenerator`.
     ///
     /// # Arguments
     ///
@@ -23,8 +23,8 @@ impl RouteService {
     ///
     /// # Returns
     ///
-    /// Returns a new RouteService instance.
-    pub fn new(route_generator: RouteGenerator) -> Self {
+    /// Returns a new `RouteService` instance.
+    pub const fn new(route_generator: RouteGenerator) -> Self {
         Self { route_generator }
     }
 

--- a/src/gui/services/route_service.rs
+++ b/src/gui/services/route_service.rs
@@ -10,14 +10,37 @@ use crate::modules::routes::RouteGenerator;
 use crate::traits::{AircraftOperations, HistoryOperations};
 
 /// Service for handling route-related operations.
-pub struct RouteService;
+pub struct RouteService {
+    route_generator: RouteGenerator,
+}
 
 impl RouteService {
+    /// Creates a new RouteService with the given RouteGenerator.
+    ///
+    /// # Arguments
+    ///
+    /// * `route_generator` - The route generator to use for route operations
+    ///
+    /// # Returns
+    ///
+    /// Returns a new RouteService instance.
+    pub fn new(route_generator: RouteGenerator) -> Self {
+        Self { route_generator }
+    }
+
+    /// Gets a reference to the available airports.
+    ///
+    /// # Returns
+    ///
+    /// Returns a slice of available airports.
+    pub fn get_available_airports(&self) -> &[Arc<Airport>] {
+        &self.route_generator.all_airports
+    }
+
     /// Generates random routes for all aircraft.
     ///
     /// # Arguments
     ///
-    /// * `route_generator` - The route generator
     /// * `aircraft` - All available aircraft
     /// * `departure_icao` - Optional departure airport ICAO
     ///
@@ -25,11 +48,13 @@ impl RouteService {
     ///
     /// Returns a vector of route table items.
     pub fn generate_random_routes(
-        route_generator: &RouteGenerator,
+        &self,
         aircraft: &[Arc<Aircraft>],
         departure_icao: Option<&str>,
     ) -> Vec<Arc<TableItem>> {
-        let routes = route_generator.generate_random_routes(aircraft, departure_icao);
+        let routes = self
+            .route_generator
+            .generate_random_routes(aircraft, departure_icao);
         routes
             .into_iter()
             .map(|route| Arc::new(TableItem::Route(route)))
@@ -40,7 +65,6 @@ impl RouteService {
     ///
     /// # Arguments
     ///
-    /// * `route_generator` - The route generator
     /// * `aircraft` - All available aircraft
     /// * `departure_icao` - Optional departure airport ICAO
     ///
@@ -48,12 +72,13 @@ impl RouteService {
     ///
     /// Returns a vector of route table items.
     pub fn generate_not_flown_routes(
-        route_generator: &RouteGenerator,
+        &self,
         aircraft: &[Arc<Aircraft>],
         departure_icao: Option<&str>,
     ) -> Vec<Arc<TableItem>> {
-        let routes =
-            route_generator.generate_random_not_flown_aircraft_routes(aircraft, departure_icao);
+        let routes = self
+            .route_generator
+            .generate_random_not_flown_aircraft_routes(aircraft, departure_icao);
         routes
             .into_iter()
             .map(|route| Arc::new(TableItem::Route(route)))
@@ -64,7 +89,6 @@ impl RouteService {
     ///
     /// # Arguments
     ///
-    /// * `route_generator` - The route generator
     /// * `aircraft` - The specific aircraft
     /// * `departure_icao` - Optional departure airport ICAO
     ///
@@ -72,11 +96,13 @@ impl RouteService {
     ///
     /// Returns a vector of route table items.
     pub fn generate_routes_for_aircraft(
-        route_generator: &RouteGenerator,
+        &self,
         aircraft: &Arc<Aircraft>,
         departure_icao: Option<&str>,
     ) -> Vec<Arc<TableItem>> {
-        let routes = route_generator.generate_routes_for_aircraft(aircraft, departure_icao);
+        let routes = self
+            .route_generator
+            .generate_routes_for_aircraft(aircraft, departure_icao);
         routes
             .into_iter()
             .map(|route| Arc::new(TableItem::Route(route)))

--- a/src/gui/state/app_state.rs
+++ b/src/gui/state/app_state.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::{PopupState, SearchState, UiState};
 use crate::gui::data::TableItem;
+use crate::gui::services::route_service::RouteService;
 use crate::models::{Aircraft, Airport};
 use crate::modules::routes::RouteGenerator;
 
@@ -17,20 +18,21 @@ pub struct AppState {
     search_state: SearchState,
     /// State for UI interactions.
     ui_state: UiState,
-    /// Route generator for creating flight routes.
-    route_generator: RouteGenerator,
+    /// Service for handling route operations.
+    route_service: RouteService,
 }
 
 impl AppState {
     /// Creates a new application state.
     pub fn new(all_aircraft: Vec<Arc<Aircraft>>, route_generator: RouteGenerator) -> Self {
+        let route_service = RouteService::new(route_generator);
         Self {
             displayed_items: Vec::new(),
             all_aircraft,
             popup_state: PopupState::new(),
             search_state: SearchState::new(),
             ui_state: UiState::new(),
-            route_generator,
+            route_service,
         }
     }
 
@@ -94,14 +96,14 @@ impl AppState {
         &mut self.ui_state
     }
 
-    /// Gets a reference to the route generator.
-    pub const fn get_route_generator(&self) -> &RouteGenerator {
-        &self.route_generator
+    /// Gets a reference to the route service.
+    pub const fn get_route_service(&self) -> &RouteService {
+        &self.route_service
     }
 
-    /// Gets a reference to the available airports from the route generator.
+    /// Gets a reference to the available airports from the route service.
     pub fn get_available_airports(&self) -> &[Arc<Airport>] {
-        &self.route_generator.all_airports
+        self.route_service.get_available_airports()
     }
 
     /// Resets all state to default values.

--- a/src/gui/state/popup_state.rs
+++ b/src/gui/state/popup_state.rs
@@ -68,30 +68,8 @@ impl PopupState {
         self.selected_route = route;
     }
 
-    /// Sets whether routes are from not flown aircraft.
-    pub const fn set_routes_from_not_flown(&mut self, from_not_flown: bool) {
-        if from_not_flown {
-            self.display_mode = DisplayMode::NotFlownRoutes;
-        } else if matches!(self.display_mode, DisplayMode::NotFlownRoutes) {
-            self.display_mode = DisplayMode::RandomRoutes;
-        }
-    }
-
-    /// Sets whether routes are for a specific aircraft.
-    pub const fn set_routes_for_specific_aircraft(&mut self, for_specific: bool) {
-        if for_specific {
-            self.display_mode = DisplayMode::SpecificAircraftRoutes;
-        } else if matches!(self.display_mode, DisplayMode::SpecificAircraftRoutes) {
-            self.display_mode = DisplayMode::RandomRoutes;
-        }
-    }
-
-    /// Sets whether the current items are random airports.
-    pub const fn set_airports_random(&mut self, airports_random: bool) {
-        if airports_random {
-            self.display_mode = DisplayMode::RandomAirports;
-        } else if matches!(self.display_mode, DisplayMode::RandomAirports) {
-            self.display_mode = DisplayMode::Other;
-        }
+    /// Sets the display mode directly.
+    pub const fn set_display_mode(&mut self, mode: DisplayMode) {
+        self.display_mode = mode;
     }
 }

--- a/src/gui/state/popup_state.rs
+++ b/src/gui/state/popup_state.rs
@@ -1,5 +1,21 @@
 use crate::gui::data::ListItemRoute;
 
+/// Represents the type of items currently being displayed.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub enum DisplayMode {
+    /// Regular routes from all aircraft.
+    #[default]
+    RandomRoutes,
+    /// Routes generated from not flown aircraft only.
+    NotFlownRoutes,
+    /// Routes for a specific selected aircraft.
+    SpecificAircraftRoutes,
+    /// Random airports with runway information.
+    RandomAirports,
+    /// Other items (history, aircraft list, etc.).
+    Other,
+}
+
 /// State for handling popup dialogs and modal interactions.
 #[derive(Default)]
 pub struct PopupState {
@@ -7,10 +23,8 @@ pub struct PopupState {
     show_alert: bool,
     /// The currently selected route.
     selected_route: Option<ListItemRoute>,
-    /// Whether the routes are generated from not flown aircraft list.
-    routes_from_not_flown: bool,
-    /// Whether the current routes are for a specific aircraft.
-    routes_for_specific_aircraft: bool,
+    /// The current display mode for items.
+    display_mode: DisplayMode,
 }
 
 impl PopupState {
@@ -31,12 +45,17 @@ impl PopupState {
 
     /// Gets whether routes are from not flown aircraft.
     pub const fn routes_from_not_flown(&self) -> bool {
-        self.routes_from_not_flown
+        matches!(self.display_mode, DisplayMode::NotFlownRoutes)
     }
 
     /// Gets whether routes are for a specific aircraft.
     pub const fn routes_for_specific_aircraft(&self) -> bool {
-        self.routes_for_specific_aircraft
+        matches!(self.display_mode, DisplayMode::SpecificAircraftRoutes)
+    }
+
+    /// Gets whether the current items are random airports.
+    pub const fn airports_random(&self) -> bool {
+        matches!(self.display_mode, DisplayMode::RandomAirports)
     }
 
     /// Sets whether to show the alert popup.
@@ -51,11 +70,28 @@ impl PopupState {
 
     /// Sets whether routes are from not flown aircraft.
     pub const fn set_routes_from_not_flown(&mut self, from_not_flown: bool) {
-        self.routes_from_not_flown = from_not_flown;
+        if from_not_flown {
+            self.display_mode = DisplayMode::NotFlownRoutes;
+        } else if matches!(self.display_mode, DisplayMode::NotFlownRoutes) {
+            self.display_mode = DisplayMode::RandomRoutes;
+        }
     }
 
     /// Sets whether routes are for a specific aircraft.
     pub const fn set_routes_for_specific_aircraft(&mut self, for_specific: bool) {
-        self.routes_for_specific_aircraft = for_specific;
+        if for_specific {
+            self.display_mode = DisplayMode::SpecificAircraftRoutes;
+        } else if matches!(self.display_mode, DisplayMode::SpecificAircraftRoutes) {
+            self.display_mode = DisplayMode::RandomRoutes;
+        }
+    }
+
+    /// Sets whether the current items are random airports.
+    pub const fn set_airports_random(&mut self, airports_random: bool) {
+        if airports_random {
+            self.display_mode = DisplayMode::RandomAirports;
+        } else if matches!(self.display_mode, DisplayMode::RandomAirports) {
+            self.display_mode = DisplayMode::Other;
+        }
     }
 }

--- a/src/gui/ui.rs
+++ b/src/gui/ui.rs
@@ -3,7 +3,7 @@ use crate::gui::data::{ListItemRoute, TableItem};
 use crate::gui::services::{RouteService, SearchService};
 use crate::gui::state::{popup_state::DisplayMode, AppState};
 use crate::models::{Aircraft, Airport, Runway};
-use crate::modules::routes::RouteGenerator;
+use crate::modules::routes::{RouteGenerator, GENERATE_AMOUNT};
 use crate::traits::{AircraftOperations, AirportOperations};
 use eframe::egui::{self};
 use log;
@@ -405,7 +405,7 @@ impl<'a> Gui<'a> {
     /// Loads more airports for infinite scrolling.
     fn load_more_airports(&mut self) {
         let route_service = self.get_route_service();
-        let airports = route_service.generate_random_airports(50);
+        let airports = route_service.generate_random_airports(GENERATE_AMOUNT);
 
         self.extend_displayed_items(airports);
 

--- a/src/gui/ui.rs
+++ b/src/gui/ui.rs
@@ -277,8 +277,8 @@ impl<'a> Gui<'a> {
     }
 
     /// Gets a reference to the route generator.
-    pub const fn get_route_generator(&self) -> &RouteGenerator {
-        self.app_state.get_route_generator()
+    pub const fn get_route_service(&self) -> &RouteService {
+        self.app_state.get_route_service()
     }
 
     /// Gets a mutable reference to the departure airport ICAO code.
@@ -364,10 +364,10 @@ impl<'a> Gui<'a> {
         };
 
         let all_aircraft = self.get_all_aircraft().to_vec(); // Clone to avoid borrowing conflicts
-        let route_generator = self.get_route_generator();
+        let route_service = self.get_route_service();
 
         let routes = if self.routes_from_not_flown() {
-            RouteService::generate_not_flown_routes(route_generator, &all_aircraft, departure_icao)
+            route_service.generate_not_flown_routes(&all_aircraft, departure_icao)
         } else if self.routes_for_specific_aircraft() {
             // If we're generating routes for a specific aircraft, use the selected aircraft
             self.get_selected_aircraft().map_or_else(
@@ -376,23 +376,15 @@ impl<'a> Gui<'a> {
                     log::warn!(
                         "No selected aircraft when generating routes for a specific aircraft"
                     );
-                    RouteService::generate_random_routes(
-                        route_generator,
-                        &all_aircraft,
-                        departure_icao,
-                    )
+                    route_service.generate_random_routes(&all_aircraft, departure_icao)
                 },
                 |selected_aircraft| {
-                    RouteService::generate_routes_for_aircraft(
-                        route_generator,
-                        selected_aircraft,
-                        departure_icao,
-                    )
+                    route_service.generate_routes_for_aircraft(selected_aircraft, departure_icao)
                 },
             )
         } else {
             // Otherwise generate random routes for all aircraft
-            RouteService::generate_random_routes(route_generator, &all_aircraft, departure_icao)
+            route_service.generate_random_routes(&all_aircraft, departure_icao)
         };
 
         self.extend_displayed_items(routes);

--- a/src/gui/ui.rs
+++ b/src/gui/ui.rs
@@ -1,7 +1,7 @@
 use crate::database::DatabasePool;
 use crate::gui::data::{ListItemRoute, TableItem};
 use crate::gui::services::{RouteService, SearchService};
-use crate::gui::state::AppState;
+use crate::gui::state::{popup_state::DisplayMode, AppState};
 use crate::models::{Aircraft, Airport, Runway};
 use crate::modules::routes::RouteGenerator;
 use crate::traits::{AircraftOperations, AirportOperations};
@@ -267,25 +267,9 @@ impl<'a> Gui<'a> {
             .set_selected_route(route);
     }
 
-    /// Sets whether routes are from not flown aircraft.
-    pub const fn set_routes_from_not_flown(&mut self, from_not_flown: bool) {
-        self.app_state
-            .get_popup_state_mut()
-            .set_routes_from_not_flown(from_not_flown);
-    }
-
-    /// Sets whether routes are for a specific aircraft.
-    pub const fn set_routes_for_specific_aircraft(&mut self, for_specific: bool) {
-        self.app_state
-            .get_popup_state_mut()
-            .set_routes_for_specific_aircraft(for_specific);
-    }
-
-    /// Sets whether the current items are random airports.
-    pub const fn set_airports_random(&mut self, airports_random: bool) {
-        self.app_state
-            .get_popup_state_mut()
-            .set_airports_random(airports_random);
+    /// Sets the display mode directly using the `DisplayMode` enum.
+    pub const fn set_display_mode(&mut self, mode: DisplayMode) {
+        self.app_state.get_popup_state_mut().set_display_mode(mode);
     }
 
     /// Gets a reference to the route generator.

--- a/src/modules/routes.rs
+++ b/src/modules/routes.rs
@@ -12,7 +12,7 @@ use crate::{
     util::calculate_haversine_distance_nm,
 };
 
-const GENERATE_AMOUNT: usize = 50;
+pub const GENERATE_AMOUNT: usize = 50;
 
 pub struct RouteGenerator {
     pub all_airports: Vec<Arc<Airport>>,

--- a/tests/gui_services/test_route_service.rs
+++ b/tests/gui_services/test_route_service.rs
@@ -113,13 +113,14 @@ mod tests {
     fn test_generate_random_routes_returns_route_items() {
         // Arrange
         let route_generator = create_test_route_generator();
+        let route_service = RouteService::new(route_generator);
         let aircraft = vec![
             Arc::new(create_test_aircraft(1, "Boeing", "737-800", "B738", 0)),
             Arc::new(create_test_aircraft(2, "Airbus", "A320", "A320", 0)),
         ];
 
         // Act
-        let result = RouteService::generate_random_routes(&route_generator, &aircraft, None);
+        let result = route_service.generate_random_routes(&aircraft, None);
 
         // Assert
         assert!(!result.is_empty(), "Should generate at least one route");
@@ -137,13 +138,13 @@ mod tests {
     fn test_generate_random_routes_with_departure_icao() {
         // Arrange
         let route_generator = create_test_route_generator();
+        let route_service = RouteService::new(route_generator);
         let aircraft = vec![Arc::new(create_test_aircraft(
             1, "Boeing", "737-800", "B738", 0,
         ))];
 
         // Act
-        let result =
-            RouteService::generate_random_routes(&route_generator, &aircraft, Some("EGLL"));
+        let result = route_service.generate_random_routes(&aircraft, Some("EGLL"));
 
         // Assert
         assert!(
@@ -166,13 +167,14 @@ mod tests {
     fn test_generate_not_flown_routes_returns_route_items() {
         // Arrange
         let route_generator = create_test_route_generator();
+        let route_service = RouteService::new(route_generator);
         let aircraft = vec![
             Arc::new(create_test_aircraft(1, "Boeing", "737-800", "B738", 0)), // Not flown
             Arc::new(create_test_aircraft(2, "Airbus", "A320", "A320", 1)),    // Flown
         ];
 
         // Act
-        let result = RouteService::generate_not_flown_routes(&route_generator, &aircraft, None);
+        let result = route_service.generate_not_flown_routes(&aircraft, None);
 
         // Assert
         assert!(
@@ -193,10 +195,11 @@ mod tests {
     fn test_generate_routes_for_aircraft_returns_route_items() {
         // Arrange
         let route_generator = create_test_route_generator();
+        let route_service = RouteService::new(route_generator);
         let aircraft = Arc::new(create_test_aircraft(1, "Boeing", "737-800", "B738", 0));
 
         // Act
-        let result = RouteService::generate_routes_for_aircraft(&route_generator, &aircraft, None);
+        let result = route_service.generate_routes_for_aircraft(&aircraft, None);
 
         // Assert
         assert!(
@@ -320,10 +323,11 @@ mod tests {
     fn test_generate_routes_empty_aircraft_list() {
         // Arrange
         let route_generator = create_test_route_generator();
+        let route_service = RouteService::new(route_generator);
         let aircraft: Vec<Arc<Aircraft>> = vec![];
 
         // Act
-        let result = RouteService::generate_random_routes(&route_generator, &aircraft, None);
+        let result = route_service.generate_random_routes(&aircraft, None);
 
         // Assert
         // The behavior here depends on the RouteGenerator implementation
@@ -339,12 +343,13 @@ mod tests {
     fn test_routes_maintain_arc_sharing() {
         // Arrange
         let route_generator = create_test_route_generator();
+        let route_service = RouteService::new(route_generator);
         let aircraft = vec![Arc::new(create_test_aircraft(
             1, "Boeing", "737-800", "N737BA", 0,
         ))];
 
         // Act
-        let result = RouteService::generate_random_routes(&route_generator, &aircraft, None);
+        let result = route_service.generate_random_routes(&aircraft, None);
 
         // Assert
         // Verify that Arc reference counting works correctly

--- a/tests/gui_services/test_route_service.rs
+++ b/tests/gui_services/test_route_service.rs
@@ -373,7 +373,11 @@ mod tests {
         let result = route_service.generate_random_airports(10);
 
         // Assert
-        assert_eq!(result.len(), 10, "Should generate the requested number of airports");
+        assert_eq!(
+            result.len(),
+            10,
+            "Should generate the requested number of airports"
+        );
 
         // Verify all items are airport items
         for item in &result {
@@ -383,7 +387,8 @@ mod tests {
                 assert!(!airport.icao.is_empty(), "Airport should have an ICAO code");
                 // Should have runway length information (either a length in ft or "N/A")
                 assert!(
-                    airport.longest_runway_length.ends_with(" ft") || airport.longest_runway_length == "N/A",
+                    airport.longest_runway_length.ends_with(" ft")
+                        || airport.longest_runway_length == "N/A",
                     "Airport should have runway length information: {}",
                     airport.longest_runway_length
                 );
@@ -403,7 +408,11 @@ mod tests {
         let result = route_service.generate_random_airports(5);
 
         // Assert
-        assert_eq!(result.len(), 5, "Should generate the requested number of airports");
+        assert_eq!(
+            result.len(),
+            5,
+            "Should generate the requested number of airports"
+        );
 
         // Since our test route generator has runway data for airports 1 and 2,
         // we should see some airports with actual runway lengths
@@ -414,14 +423,15 @@ mod tests {
                     found_runway_data = true;
                     // The test data should have runway lengths of 3902 ft or 4215 ft
                     assert!(
-                        airport.longest_runway_length == "3902 ft" || airport.longest_runway_length == "4215 ft",
+                        airport.longest_runway_length == "3902 ft"
+                            || airport.longest_runway_length == "4215 ft",
                         "Unexpected runway length: {}",
                         airport.longest_runway_length
                     );
                 }
             }
         }
-        
+
         // Note: This test might occasionally fail if the random generator
         // doesn't select any airports with runway data, but it's unlikely
         // with multiple attempts

--- a/tests/gui_services/test_search_service.rs
+++ b/tests/gui_services/test_search_service.rs
@@ -8,11 +8,11 @@ mod tests {
     use std::sync::Arc;
 
     /// Helper function to create a test airport table item.
-    fn create_airport_item(id: &str, name: &str, icao: &str) -> Arc<TableItem> {
+    fn create_airport_item(name: &str, icao: &str, runway_length: &str) -> Arc<TableItem> {
         Arc::new(TableItem::Airport(ListItemAirport::new(
-            id.to_string(),
             name.to_string(),
             icao.to_string(),
+            runway_length.to_string(),
         )))
     }
 
@@ -66,9 +66,9 @@ mod tests {
     fn test_filter_items_empty_query_returns_all_items() {
         // Arrange
         let items = vec![
-            create_airport_item("1", "London Heathrow", "EGLL"),
-            create_airport_item("2", "Charles de Gaulle", "LFPG"),
-            create_airport_item("3", "JFK International", "KJFK"),
+            create_airport_item("London Heathrow", "EGLL", "3902 ft"),
+            create_airport_item("Charles de Gaulle", "LFPG", "4215 ft"),
+            create_airport_item("JFK International", "KJFK", "4423 ft"),
         ];
 
         // Act
@@ -84,9 +84,9 @@ mod tests {
     fn test_filter_items_with_query_filters_correctly() {
         // Arrange
         let items = vec![
-            create_airport_item("1", "London Heathrow", "EGLL"),
-            create_airport_item("2", "Charles de Gaulle", "LFPG"),
-            create_airport_item("3", "JFK International", "KJFK"),
+            create_airport_item("London Heathrow", "EGLL", "3902 ft"),
+            create_airport_item("Charles de Gaulle", "LFPG", "4215 ft"),
+            create_airport_item("JFK International", "KJFK", "4423 ft"),
         ];
 
         // Act
@@ -105,8 +105,8 @@ mod tests {
     fn test_filter_items_case_insensitive() {
         // Arrange
         let items = vec![
-            create_airport_item("1", "London Heathrow", "EGLL"),
-            create_airport_item("2", "Charles de Gaulle", "LFPG"),
+            create_airport_item("London Heathrow", "EGLL", "3902 ft"),
+            create_airport_item("Charles de Gaulle", "LFPG", "4215 ft"),
         ];
 
         // Act
@@ -124,8 +124,8 @@ mod tests {
     fn test_filter_items_no_matches_returns_empty() {
         // Arrange
         let items = vec![
-            create_airport_item("1", "London Heathrow", "EGLL"),
-            create_airport_item("2", "Charles de Gaulle", "LFPG"),
+            create_airport_item("London Heathrow", "EGLL", "3902 ft"),
+            create_airport_item("Charles de Gaulle", "LFPG", "4215 ft"),
         ];
 
         // Act
@@ -139,8 +139,8 @@ mod tests {
     fn test_filter_items_matches_icao_codes() {
         // Arrange
         let items = vec![
-            create_airport_item("1", "London Heathrow", "EGLL"),
-            create_airport_item("2", "Charles de Gaulle", "LFPG"),
+            create_airport_item("London Heathrow", "EGLL", "3902 ft"),
+            create_airport_item("Charles de Gaulle", "LFPG", "4215 ft"),
         ];
 
         // Act
@@ -220,7 +220,7 @@ mod tests {
         // Arrange
         let aircraft = create_test_aircraft(1, "Boeing", "737-800", "B738", 0);
         let items = vec![
-            create_airport_item("1", "London Heathrow", "EGLL"),
+            create_airport_item("London Heathrow", "EGLL", "3902 ft"),
             create_aircraft_item(&aircraft),
             create_history_item("1", "EGLL", "LFPG", "Boeing 737", "2023-01-01"),
         ];
@@ -237,9 +237,9 @@ mod tests {
     fn test_filter_items_partial_matches() {
         // Arrange
         let items = vec![
-            create_airport_item("1", "London Heathrow", "EGLL"),
-            create_airport_item("2", "London Gatwick", "EGKK"),
-            create_airport_item("3", "Manchester", "EGCC"),
+            create_airport_item("London Heathrow", "EGLL", "3902 ft"),
+            create_airport_item("London Gatwick", "EGKK", "3316 ft"),
+            create_airport_item("Manchester", "EGCC", "3200 ft"),
         ];
 
         // Act


### PR DESCRIPTION
- Convert RouteService from unit struct to struct containing RouteGenerator
- Add RouteService::new() constructor and get_available_airports() method
- Update all route generation methods to use &self instead of RouteGenerator parameter
- Modify AppState to hold RouteService instead of RouteGenerator
- Update UI components to use RouteService instance methods
- Update all tests to work with new RouteService API
- Maintain all existing functionality while improving encapsulation