### PR TITLE
feat: Implement flight history search and expand statistics

### DIFF
--- a/src/gui/components/table_display.rs
+++ b/src/gui/components/table_display.rs
@@ -257,13 +257,42 @@ impl TableDisplay {
                         ui.label(format!("{} NM", stats.total_distance));
                         ui.end_row();
 
+                        ui.label("Average Flight Distance:");
+                        ui.label(format!("{:.2} NM", stats.average_flight_distance));
+                        ui.end_row();
+
+                        ui.label("Longest Flight:");
+                        ui.label(stats.longest_flight.as_deref().unwrap_or("None"));
+                        ui.end_row();
+
+                        ui.label("Shortest Flight:");
+                        ui.label(stats.shortest_flight.as_deref().unwrap_or("None"));
+                        ui.end_row();
+
                         ui.label("Most Flown Aircraft:");
                         ui.label(stats.most_flown_aircraft.as_deref().unwrap_or("None"));
                         ui.end_row();
 
                         ui.label("Most Visited Airport:");
                         ui.label(stats.most_visited_airport.as_deref().unwrap_or("None"));
+                        ui.end_row();
 
+                        ui.label("Favorite Departure Airport:");
+                        ui.label(
+                            stats
+                                .favorite_departure_airport
+                                .as_deref()
+                                .unwrap_or("None"),
+                        );
+                        ui.end_row();
+
+                        ui.label("Favorite Arrival Airport:");
+                        ui.label(
+                            stats
+                                .favorite_arrival_airport
+                                .as_deref()
+                                .unwrap_or("None"),
+                        );
                         ui.end_row();
                     });
             }

--- a/src/gui/data/table_items.rs
+++ b/src/gui/data/table_items.rs
@@ -117,7 +117,12 @@ impl TableItem {
                     || route.aircraft.manufacturer.to_lowercase().contains(&query)
                     || route.aircraft.variant.to_lowercase().contains(&query)
             }
-            Self::History(_) => false,
+            Self::History(history) => {
+                history.departure_icao.to_lowercase().contains(&query)
+                    || history.arrival_icao.to_lowercase().contains(&query)
+                    || history.aircraft_name.to_lowercase().contains(&query)
+                    || history.date.to_lowercase().contains(&query)
+            }
             Self::Aircraft(aircraft) => {
                 aircraft.manufacturer.to_lowercase().contains(&query)
                     || aircraft.variant.to_lowercase().contains(&query)

--- a/src/gui/services/history_service.rs
+++ b/src/gui/services/history_service.rs
@@ -1,4 +1,4 @@
-use crate::gui::data::ListItemHistory;
+use crate::gui::data::{ListItemHistory, TableItem};
 
 /// Filters history items based on search text.
 ///
@@ -14,14 +14,10 @@ pub fn filter_items(items: &[ListItemHistory], search_text: &str) -> Vec<ListIte
     if search_text.is_empty() {
         items.to_vec()
     } else {
-        let search_lower = search_text.to_lowercase();
         items
             .iter()
             .filter(|item| {
-                item.departure_icao.to_lowercase().contains(&search_lower)
-                    || item.arrival_icao.to_lowercase().contains(&search_lower)
-                    || item.aircraft_name.to_lowercase().contains(&search_lower)
-                    || item.date.to_lowercase().contains(&search_lower)
+                TableItem::History((*item).clone()).matches_query(search_text)
             })
             .cloned()
             .collect()

--- a/tests/gui_services/test_search_service.rs
+++ b/tests/gui_services/test_search_service.rs
@@ -135,8 +135,37 @@ mod tests {
         let result = SearchService::filter_items(&items, "EGLL");
 
         // Assert
-        // History items don't support search, so no results expected
-        assert_eq!(result.len(), 0);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_items_history_by_aircraft() {
+        // Arrange
+        let items = vec![
+            create_history_item("1", "EGLL", "LFPG", "Boeing 737", "2023-01-01"),
+            create_history_item("2", "KJFK", "EGLL", "Airbus A320", "2023-01-02"),
+        ];
+
+        // Act
+        let result = SearchService::filter_items(&items, "Boeing");
+
+        // Assert
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_filter_items_history_by_date() {
+        // Arrange
+        let items = vec![
+            create_history_item("1", "EGLL", "LFPG", "Boeing 737", "2023-01-01"),
+            create_history_item("2", "KJFK", "EGLL", "Airbus A320", "2023-01-02"),
+        ];
+
+        // Act
+        let result = SearchService::filter_items(&items, "2023-01-01");
+
+        // Assert
+        assert_eq!(result.len(), 1);
     }
 
     #[test]
@@ -149,11 +178,10 @@ mod tests {
         ];
 
         // Act
-        let result = SearchService::filter_items(&items, "london");
+        let result = SearchService::filter_items(&items, "EGLL");
 
         // Assert
-        // Only airport item should match (history search is not implemented)
-        assert_eq!(result.len(), 1);
+        assert_eq!(result.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
This commit introduces two new features:
- Flight history search: Users can now search their flight history by departure/arrival ICAO, aircraft name, or date.
- Expanded statistics: The statistics page now includes average flight distance, longest/shortest flights, and favorite departure/arrival airports.

The UI has been updated to reflect these changes.