### PR TITLE
fix: correct release artifact paths and upload logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,15 +70,19 @@ jobs:
         run: |
           build_msi.bat
 
-      - name: Upload Artifacts for Release
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Upload Linux Release Artifact
+        if: matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v4
         with:
-          name: flight-planner-${{ matrix.os }}
-          path: |
-            flight-planner-linux.tar.gz
-            dist/FlightPlannerSetup.msi
-          if-no-files-found: ignore
+          name: flight-planner-linux
+          path: flight-planner-linux.tar.gz
+
+      - name: Upload Windows Release Artifact  
+        if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: flight-planner-windows
+          path: dist/FlightPlannerSetup.msi
 
   create-release:
     name: Create GitHub Release
@@ -92,11 +96,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
-          merge-multiple: true
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            dist/flight-planner-windows-latest/FlightPlannerSetup.msi
-            dist/flight-planner-ubuntu-latest/flight-planner-linux.tar.gz
+            dist/flight-planner-windows/FlightPlannerSetup.msi
+            dist/flight-planner-linux/flight-planner-linux.tar.gz


### PR DESCRIPTION
- Split artifact uploads by platform to avoid path confusion
- Use platform-specific artifact names (flight-planner-linux, flight-planner-windows)
- Fix download paths to match the new artifact structure
- Remove merge-multiple option that was causing path issues
- This resolves the 'pattern does not match any files' error in releases

Fixes the v1.0.5 release artifact upload issues where files were uploaded with wrong paths and couldn't be found during release creation.