### PR TITLE
chore: bump version to v1.0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flight_planner"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2024"
 build = "build.rs"
 


### PR DESCRIPTION
Patch release to fix artifact upload issues in v1.0.5 release workflow. This version includes the corrected release artifact paths and upload logic.