### PR TITLE
chore: bump version to v1.0.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,14 @@ jobs:
       - name: Package Linux Release
         if: matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/tags/v')
         run: |
-          mkdir -p release_package
+          mkdir -p release_package/assets/icons
           cp target/release/flight_planner release_package/
           cp aircrafts.csv release_package/
           cp com.github.daan.flight-planner.desktop release_package/
-          cp -r assets release_package/assets
+          # Only include icons actually needed for desktop integration
+          cp assets/icons/icon-64x64.png release_package/assets/icons/
+          cp assets/icons/icon-128x128.png release_package/assets/icons/
+          cp assets/icons/icon-256x256.png release_package/assets/icons/
           cp install.sh release_package/install.sh
           cp uninstall.sh release_package/uninstall.sh
           chmod +x release_package/install.sh release_package/uninstall.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "flight_planner"
-version = "1.0.4"
+version = "1.0.7"
 dependencies = [
  "chrono",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flight_planner"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2024"
 build = "build.rs"
 


### PR DESCRIPTION
perf: optimize Linux package size while preserving desktop integration

- Include only essential icons (64x64, 128x128, 256x256) for desktop menus
- Remove unnecessary icon sizes to reduce package size
- Maintain full KDE Plasma/GNOME/XFCE menu integration
- Keep .desktop file for proper application launcher support
- Balances download size with desktop environment compatibility

This reduces Linux package size significantly while ensuring the app appears correctly in all desktop environment application menus.