### PR TITLE
Fix incorrect date conversion in `format_date_for_display`

### DIFF
--- a/src/date_utils.rs
+++ b/src/date_utils.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Local, NaiveDate, TimeZone, Utc};
+use chrono::{NaiveDate, Utc};
 
 /// Utility functions for consistent date handling across the application.
 /// All dates are stored in UTC but displayed in local time.
@@ -15,20 +15,8 @@ pub fn format_date_for_display(utc_date: Option<&String>) -> String {
             // Parse the UTC date string
             match NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
                 Ok(naive_date) => {
-                    // Convert to UTC DateTime at start of day
-                    match naive_date.and_hms_opt(0, 0, 0) {
-                        Some(naive_datetime) => {
-                            let utc_datetime = Utc.from_utc_datetime(&naive_datetime);
-                            // Convert to local time and format for display
-                            let local_datetime: DateTime<Local> =
-                                utc_datetime.with_timezone(&Local);
-                            local_datetime.format("%Y-%m-%d").to_string()
-                        }
-                        None => {
-                            // This should never happen with (0, 0, 0), but handle gracefully
-                            date_str.clone()
-                        }
-                    }
+                    // Format the date directly without timezone conversion
+                    naive_date.format("%Y-%m-%d").to_string()
                 }
                 Err(_) => {
                     // If parsing fails, return the original string as fallback

--- a/tests/date_utils_tests.rs
+++ b/tests/date_utils_tests.rs
@@ -42,3 +42,13 @@ fn test_format_date_for_display_invalid() {
         "invalid-date"
     );
 }
+
+#[test]
+fn test_format_date_for_display_utc_is_preserved() {
+    let utc_date = Some("2024-01-01".to_string());
+    // In timezones behind UTC, the current implementation will convert this to "2023-12-31"
+    assert_eq!(
+        format_date_for_display(utc_date.as_ref()),
+        "2024-01-01"
+    );
+}


### PR DESCRIPTION
The `format_date_for_display` function was incorrectly converting UTC dates to the local timezone, which could cause the date to be off by one day depending on the user's timezone.

This commit fixes the issue by removing the timezone conversion and formatting the `NaiveDate` directly.

A new test case has been added to verify that the date is preserved regardless of the local timezone.