### PR TITLE
Refactor R-tree struct and UI model access

### DIFF
--- a/src/gui/services/app_service.rs
+++ b/src/gui/services/app_service.rs
@@ -60,7 +60,7 @@ impl AppService {
         let spatial_airports = rstar::RTree::bulk_load(
             airports
                 .iter()
-                .map(|airport| crate::gui::ui::SpatialAirport {
+                .map(|airport| crate::models::airport::SpatialAirport {
                     airport: Arc::clone(airport),
                 })
                 .collect(),
@@ -309,5 +309,22 @@ impl AppService {
     /// Gets the display name for an airport by its ICAO
     pub fn get_airport_display_name(&self, icao: &str) -> String {
         services::airport_service::get_display_name(&self.airports, icao)
+    }
+
+    pub fn get_selected_airport_icao(&self, selected_airport: &Option<Arc<Airport>>) -> Option<String> {
+        selected_airport.as_ref().map(|a| a.ICAO.clone())
+    }
+
+    pub fn create_list_item_for_airport(&self, airport: &Arc<Airport>) -> ListItemAirport {
+        let runways = self.get_runways_for_airport(airport);
+        let runway_length = runways
+            .iter()
+            .max_by_key(|r| r.Length)
+            .map_or("No runways".to_string(), |r| format!("{}ft", r.Length));
+        ListItemAirport::new(
+            airport.Name.clone(),
+            airport.ICAO.clone(),
+            runway_length,
+        )
     }
 }

--- a/src/models/airport.rs
+++ b/src/models/airport.rs
@@ -1,5 +1,7 @@
 use crate::schema::Airports;
 use diesel::prelude::*;
+use rstar::{AABB, RTreeObject};
+use std::sync::Arc;
 
 #[derive(Queryable, Identifiable, Debug, PartialEq, Clone, Default)]
 #[diesel(primary_key(ID))]
@@ -17,4 +19,18 @@ pub struct Airport {
     pub TransitionLevel: Option<i32>,
     pub SpeedLimit: Option<i32>,
     pub SpeedLimitAltitude: Option<i32>,
+}
+
+/// A spatial index object for airports.
+pub struct SpatialAirport {
+    pub airport: Arc<Airport>,
+}
+
+impl RTreeObject for SpatialAirport {
+    type Envelope = AABB<[f64; 2]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        let point = [self.airport.Latitude, self.airport.Longtitude];
+        AABB::from_point(point)
+    }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,5 @@
 mod aircraft;
-mod airport;
+pub mod airport;
 mod history;
 mod runway;
 

--- a/src/modules/airport.rs
+++ b/src/modules/airport.rs
@@ -1,6 +1,6 @@
 use crate::database::{DatabaseConnections, DatabasePool};
 use crate::errors::AirportSearchError;
-use crate::gui::ui::SpatialAirport;
+use crate::models::airport::SpatialAirport;
 use crate::models::{Aircraft, Airport, Runway};
 use crate::schema::Airports::dsl::{Airports, ID, Latitude, Longtitude};
 use crate::traits::{AircraftOperations, AirportOperations};

--- a/src/modules/routes.rs
+++ b/src/modules/routes.rs
@@ -17,7 +17,7 @@ pub const GENERATE_AMOUNT: usize = 50;
 pub struct RouteGenerator {
     pub all_airports: Vec<Arc<Airport>>,
     pub all_runways: std::collections::HashMap<i32, Arc<Vec<Runway>>>,
-    pub spatial_airports: rstar::RTree<crate::gui::ui::SpatialAirport>,
+    pub spatial_airports: rstar::RTree<crate::models::airport::SpatialAirport>,
 }
 
 impl RouteGenerator {

--- a/tests/airport_tests.rs
+++ b/tests/airport_tests.rs
@@ -2,7 +2,7 @@ use diesel::connection::SimpleConnection;
 use diesel::{Connection, SqliteConnection};
 use flight_planner::database::DatabaseConnections;
 use flight_planner::errors::AirportSearchError;
-use flight_planner::gui::ui::SpatialAirport;
+use flight_planner::models::airport::SpatialAirport;
 use flight_planner::models::{Aircraft, Airport, Runway};
 use flight_planner::modules::airport::*;
 use flight_planner::traits::AirportOperations;

--- a/tests/routes_tests.rs
+++ b/tests/routes_tests.rs
@@ -1,4 +1,5 @@
 use flight_planner::gui::data::ListItemRoute;
+use flight_planner::models::airport::SpatialAirport;
 use flight_planner::models::{Aircraft, Airport, Runway};
 use flight_planner::modules::routes::*;
 use rstar::RTree;
@@ -8,7 +9,7 @@ use std::sync::Arc;
 type AircraftVec = Vec<Arc<Aircraft>>;
 type AirportVec = Vec<Arc<Airport>>;
 type RunwayMap = HashMap<i32, Arc<Vec<Runway>>>;
-type AirportRTree = RTree<flight_planner::gui::ui::SpatialAirport>;
+type AirportRTree = RTree<SpatialAirport>;
 
 fn create_test_data() -> (AircraftVec, AirportVec, RunwayMap, AirportRTree) {
     let aircraft1 = Arc::new(Aircraft {
@@ -98,7 +99,7 @@ fn create_test_data() -> (AircraftVec, AirportVec, RunwayMap, AirportRTree) {
     let spatial_airports = RTree::bulk_load(
         all_airports
             .iter()
-            .map(|airport| flight_planner::gui::ui::SpatialAirport {
+            .map(|airport| SpatialAirport {
                 airport: Arc::clone(airport),
             })
             .collect(),

--- a/tests/rtree_tests.rs
+++ b/tests/rtree_tests.rs
@@ -1,0 +1,73 @@
+use flight_planner::models::airport::{Airport, SpatialAirport};
+use rstar::{AABB, RTree};
+use std::sync::Arc;
+
+#[test]
+fn test_spatial_airport_rtree() {
+    // 1. Create Airport instances
+    let airport1 = Arc::new(Airport {
+        ID: 1,
+        Name: "Airport 1".to_string(),
+        ICAO: "APT1".to_string(),
+        Latitude: 40.7128,
+        Longtitude: -74.0060,
+        ..Default::default()
+    });
+
+    let airport2 = Arc::new(Airport {
+        ID: 2,
+        Name: "Airport 2".to_string(),
+        ICAO: "APT2".to_string(),
+        Latitude: 34.0522,
+        Longtitude: -118.2437,
+        ..Default::default()
+    });
+
+    let airport3 = Arc::new(Airport {
+        ID: 3,
+        Name: "Airport 3".to_string(),
+        ICAO: "APT3".to_string(),
+        Latitude: 41.8781,
+        Longtitude: -87.6298,
+        ..Default::default()
+    });
+
+    // 2. Wrap them in SpatialAirport
+    let spatial_airports = vec![
+        SpatialAirport {
+            airport: Arc::clone(&airport1),
+        },
+        SpatialAirport {
+            airport: Arc::clone(&airport2),
+        },
+        SpatialAirport {
+            airport: Arc::clone(&airport3),
+        },
+    ];
+
+    // 3. Create an RTree
+    let rtree = RTree::bulk_load(spatial_airports);
+
+    // 4. Define a search envelope (around New York)
+    let envelope = AABB::from_corners([40.0, -75.0], [42.0, -73.0]);
+
+    // 5. Locate airports within the envelope
+    let found_airports: Vec<_> = rtree.locate_in_envelope(&envelope).collect();
+
+    assert_eq!(found_airports.len(), 1);
+    assert_eq!(found_airports[0].airport.ID, 1);
+
+    // 6. Test with an envelope that contains no airports
+    let empty_envelope = AABB::from_corners([0.0, 0.0], [1.0, 1.0]);
+    let no_airports_found: Vec<_> = rtree.locate_in_envelope(&empty_envelope).collect();
+    assert!(no_airports_found.is_empty());
+}
+
+#[test]
+fn test_empty_rtree() {
+    // 7. Test with an empty R-tree
+    let empty_rtree: RTree<SpatialAirport> = RTree::new();
+    let envelope = AABB::from_corners([0.0, 0.0], [90.0, 180.0]);
+    let found_airports: Vec<_> = empty_rtree.locate_in_envelope(&envelope).collect();
+    assert!(found_airports.is_empty());
+}


### PR DESCRIPTION
- Moved `SpatialAirport` struct from `gui/ui.rs` to `models/airport.rs` to improve code organization.
- Added tests for the R-tree functionality in `tests/rtree_tests.rs`.
- Refactored `gui/ui.rs` to use methods from `AppService` instead of directly accessing model fields, decoupling the UI from the data models.