### PR TITLE
feat: Add airport name to history view

### DIFF
--- a/src/gui/components/table_display.rs
+++ b/src/gui/components/table_display.rs
@@ -249,10 +249,16 @@ impl TableDisplay {
             ui.label(&history.aircraft_name);
         });
         row.col(|ui| {
-            ui.label(&history.departure_icao);
+            ui.label(format!(
+                "{} ({})",
+                history.departure_airport_name, history.departure_icao
+            ));
         });
         row.col(|ui| {
-            ui.label(&history.arrival_icao);
+            ui.label(format!(
+                "{} ({})",
+                history.arrival_airport_name, history.arrival_icao
+            ));
         });
         row.col(|ui| {
             ui.label(&history.date);

--- a/src/gui/data/list_items.rs
+++ b/src/gui/data/list_items.rs
@@ -26,8 +26,12 @@ pub struct ListItemHistory {
     pub id: String,
     /// The departure ICAO code.
     pub departure_icao: String,
+    /// The name of the departure airport.
+    pub departure_airport_name: String,
     /// The arrival ICAO code.
     pub arrival_icao: String,
+    /// The name of the arrival airport.
+    pub arrival_airport_name: String,
     /// The aircraft ID.
     pub aircraft_name: String,
     /// The date of the flight.

--- a/src/gui/services/app_service.rs
+++ b/src/gui/services/app_service.rs
@@ -95,7 +95,8 @@ impl AppService {
             &route_generator.all_runways,
         );
         let route_items = DataOperations::generate_random_routes(&route_generator, &aircraft, None);
-        let history_items = DataOperations::load_history_data(&mut database_pool, &aircraft)?;
+        let history_items =
+            DataOperations::load_history_data(&mut database_pool, &aircraft, &airports)?;
 
         Ok(Self {
             database_pool,
@@ -261,8 +262,11 @@ impl AppService {
         )?;
 
         // Refresh history items
-        self.history_items =
-            DataOperations::load_history_data(&mut self.database_pool, &self.aircraft)?;
+        self.history_items = DataOperations::load_history_data(
+            &mut self.database_pool,
+            &self.aircraft,
+            &self.airports,
+        )?;
 
         // Invalidate statistics cache since a new flight was added
         self.invalidate_statistics_cache();
@@ -275,8 +279,11 @@ impl AppService {
         DataOperations::mark_route_as_flown(&mut self.database_pool, route)?;
 
         // Refresh history items
-        self.history_items =
-            DataOperations::load_history_data(&mut self.database_pool, &self.aircraft)?;
+        self.history_items = DataOperations::load_history_data(
+            &mut self.database_pool,
+            &self.aircraft,
+            &self.airports,
+        )?;
 
         // Invalidate statistics cache since a new flight was added
         self.invalidate_statistics_cache();


### PR DESCRIPTION
This commit enhances the flight history view by displaying the full airport name alongside the ICAO code for both departure and arrival airports.

- Modified the `ListItemHistory` struct to include `departure_airport_name` and `arrival_airport_name` fields.
- Updated the `load_history_data` function in `data_operations.rs` to fetch and populate the airport names.
- Adjusted the UI in `table_display.rs` to render the airport names in the format 'Airport Name (ICAO)'.