### PR TITLE
feat: Center the 'Add History' popup

### DIFF
--- a/src/gui/components/add_history_popup.rs
+++ b/src/gui/components/add_history_popup.rs
@@ -37,6 +37,7 @@ impl AddHistoryPopup {
         let mut open = true;
 
         egui::Window::new("Add History Entry")
+            .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
             .open(&mut open)
             .collapsible(false)
             .resizable(false)


### PR DESCRIPTION
The 'Add History' popup was previously not centered on the screen, leading to an inconsistent user experience.

This change uses the `egui::Window::anchor` method to position the popup in the center of the application window.