### PR TITLE
Fix(database): Implement get_install_shared_data_dir for Windows

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -53,6 +53,15 @@ pub(crate) fn get_install_shared_data_dir() -> PathBuf {
     PathBuf::from("/usr/local/share/flight-planner")
 }
 
+/// Get the path to the installation shared data directory (Windows-specific).
+///
+/// On Windows, this function returns the current directory (`.`) to allow
+/// finding `aircrafts.csv` when it's placed alongside the executable.
+#[cfg(target_os = "windows")]
+pub(crate) fn get_install_shared_data_dir() -> PathBuf {
+    PathBuf::from(".")
+}
+
 pub struct DatabaseConnections {
     pub aircraft_connection: SqliteConnection,
     pub airport_connection: SqliteConnection,
@@ -128,3 +137,15 @@ impl Default for DatabasePool {
 }
 
 impl DatabaseOperations for DatabasePool {}
+
+#[cfg(test)]
+mod tests {
+    use super::get_install_shared_data_dir;
+    use std::path::PathBuf;
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_get_install_shared_data_dir_windows() {
+        assert_eq!(get_install_shared_data_dir(), PathBuf::from("."));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,7 @@ use log4rs::encode::pattern::PatternEncoder;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::database::{DatabasePool, get_airport_db_path};
-#[cfg(not(target_os = "windows"))]
-use crate::database::get_install_shared_data_dir;
+use crate::database::{DatabasePool, get_airport_db_path, get_install_shared_data_dir};
 use crate::errors::Error;
 use eframe::AppCreator;
 use egui::ViewportBuilder;
@@ -70,8 +68,7 @@ fn get_aircraft_csv_candidate_paths() -> Vec<PathBuf> {
     // Current working directory
     candidates.push(PathBuf::from("aircrafts.csv"));
 
-    // System-wide install location via helper (non-Windows only)
-    #[cfg(not(target_os = "windows"))]
+    // System-wide install location via helper
     candidates.push(get_install_shared_data_dir().join("aircrafts.csv"));
 
     candidates


### PR DESCRIPTION
The `get_install_shared_data_dir` function was missing an implementation for the Windows target, causing an important search path for `aircrafts.csv` to be skipped. This change provides the Windows-specific implementation, which returns the current directory (`.`), and removes the conditional compilation that prevented it from being called.

A new test has been added to verify the Windows implementation, and all existing tests have been run to ensure no regressions were introduced.