### PR TITLE
Refactor `get_install_shared_data_dir` to return a `Result`

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -33,37 +33,47 @@ pub fn get_airport_db_path() -> Result<PathBuf, Error> {
 ///
 /// Best-effort and side-effect free.
 #[cfg(not(target_os = "windows"))]
-pub(crate) fn get_install_shared_data_dir() -> PathBuf {
+pub(crate) fn get_install_shared_data_dir() -> Result<PathBuf, std::io::Error> {
     // 1) Full share dir override
     if let Ok(dir) = std::env::var("FLIGHT_PLANNER_SHARE_DIR") {
-        return PathBuf::from(dir);
+        return Ok(PathBuf::from(dir));
     }
 
     // 2) Prefix override via env
     if let Ok(prefix) = std::env::var("FLIGHT_PLANNER_PREFIX") {
-        return PathBuf::from(prefix).join("share/flight-planner");
+        return Ok(PathBuf::from(prefix).join("share/flight-planner"));
     }
 
     // 3) Compile-time prefix from build.rs (INSTALL_PREFIX)
     if let Some(prefix) = option_env!("INSTALL_PREFIX") {
-        return PathBuf::from(prefix).join("share/flight-planner");
+        return Ok(PathBuf::from(prefix).join("share/flight-planner"));
     }
 
     // 4) Fallback default
-    PathBuf::from("/usr/local/share/flight-planner")
+    Ok(PathBuf::from("/usr/local/share/flight-planner"))
 }
 
 /// Get the path to the installation shared data directory (Windows-specific).
 ///
-/// On Windows, this function returns the current directory (`.`) to allow
-/// finding `aircrafts.csv` when it's placed alongside the executable.
+/// On Windows, this function returns the directory containing the executable,
+/// allowing `aircrafts.csv` to be found when placed alongside it.
+/// This implementation now supports `FLIGHT_PLANNER_SHARE_DIR` for testing
+/// and consistency with the non-Windows version.
 #[cfg(target_os = "windows")]
-pub(crate) fn get_install_shared_data_dir() -> PathBuf {
-    if let Ok(mut exe_path) = std::env::current_exe() {
-        exe_path.pop();
-        return exe_path;
+pub(crate) fn get_install_shared_data_dir() -> Result<PathBuf, std::io::Error> {
+    // 1) Full share dir override (for testing and consistency)
+    if let Ok(dir) = std::env::var("FLIGHT_PLANNER_SHARE_DIR") {
+        return Ok(PathBuf::from(dir));
     }
-    PathBuf::from(".")
+
+    // 2) Directory of the executable
+    match std::env::current_exe() {
+        Ok(mut exe_path) => {
+            exe_path.pop();
+            Ok(exe_path)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 pub struct DatabaseConnections {
@@ -148,8 +158,38 @@ mod tests {
     #[cfg(target_os = "windows")]
     fn test_get_install_shared_data_dir_windows() {
         use super::get_install_shared_data_dir;
+
+        // Test the default case (no env var)
         let mut exe_path = std::env::current_exe().unwrap();
         exe_path.pop();
-        assert_eq!(get_install_shared_data_dir(), exe_path);
+        assert_eq!(
+            get_install_shared_data_dir().unwrap(),
+            exe_path,
+            "Should return the executable's directory by default"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_get_install_shared_data_dir_windows_with_env_var() {
+        use super::get_install_shared_data_dir;
+        use std::env;
+
+        // This test modifies the environment, which is not thread-safe.
+        // It's recommended to run tests with `RUST_TEST_THREADS=1`.
+        unsafe {
+            let test_dir = "C:\\test-share-dir";
+            env::set_var("FLIGHT_PLANNER_SHARE_DIR", test_dir);
+
+            let expected_path = PathBuf::from(test_dir);
+            assert_eq!(
+                get_install_shared_data_dir().unwrap(),
+                expected_path,
+                "Should return the path from the environment variable"
+            );
+
+            // Clean up the environment variable
+            env::remove_var("FLIGHT_PLANNER_SHARE_DIR");
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,12 +47,7 @@ pub fn get_app_data_dir() -> Result<PathBuf, Error> {
 
 /// Try to locate an aircrafts.csv file in common locations
 fn find_aircraft_csv_path() -> Option<PathBuf> {
-    let mut candidates = get_aircraft_csv_candidate_paths();
-
-    // Remove duplicates: on Windows, get_install_shared_data_dir can be "."
-    // which might already be in the search path.
-    candidates.sort();
-    candidates.dedup();
+    let candidates = get_aircraft_csv_candidate_paths();
 
     candidates.into_iter().find(|path| path.exists())
 }
@@ -69,7 +64,9 @@ fn get_aircraft_csv_candidate_paths() -> Vec<PathBuf> {
     candidates.push(PathBuf::from("aircrafts.csv"));
 
     // System-wide install location via helper
-    candidates.push(get_install_shared_data_dir().join("aircrafts.csv"));
+    if let Ok(shared_dir) = get_install_shared_data_dir() {
+        candidates.push(shared_dir.join("aircrafts.csv"));
+    }
 
     candidates
 }
@@ -390,34 +387,3 @@ fn run() -> Result<(), Error> {
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    #[cfg(target_os = "windows")]
-    fn test_get_aircraft_csv_candidate_paths_no_duplicates_on_windows() {
-        use super::get_aircraft_csv_candidate_paths;
-        use std::collections::HashSet;
-        let candidates = get_aircraft_csv_candidate_paths();
-        let unique_candidates: HashSet<_> = candidates.iter().collect();
-        assert_eq!(
-            candidates.len(),
-            unique_candidates.len(),
-            "get_aircraft_csv_candidate_paths should not produce duplicate paths on Windows"
-        );
-    }
-
-    #[test]
-    #[cfg(target_os = "windows")]
-    fn test_find_aircraft_csv_path_no_duplicates_on_windows() {
-        use super::get_aircraft_csv_candidate_paths;
-        let mut candidates = get_aircraft_csv_candidate_paths();
-        let original_len = candidates.len();
-        candidates.sort();
-        candidates.dedup();
-        let unique_len = candidates.len();
-        assert_eq!(
-            original_len, unique_len,
-            "Duplicate paths found in aircrafts.csv search on Windows"
-        );
-    }
-}


### PR DESCRIPTION
This commit refactors the `get_install_shared_data_dir` function in `src/database.rs` to return a `Result<PathBuf, std::io::Error>` instead of a raw `PathBuf`.

Previously, the Windows implementation of this function would fall back to returning the current directory (`.`) if it failed to determine the executable's path. This led to duplicate search paths for `aircrafts.csv` because the current directory was already being added to the search list elsewhere. While this was worked around by sorting and deduplicating the list, it was an inefficient solution that masked the underlying problem.

This change addresses the root cause by:
1.  Modifying the function signature for both Windows and non-Windows targets to return a `Result`, making error handling explicit.
2.  Removing the problematic fallback to `.` on Windows.
3.  Updating the call site in `src/lib.rs` to correctly handle the `Result`.
4.  Removing the now-redundant sorting and deduplication logic.
5.  Adding a new test to verify the updated behavior on Windows, including support for the `FLIGHT_PLANNER_SHARE_DIR` environment variable for consistency and testability.
6.  Removing obsolete tests related to the duplicate path issue.

This makes the file path handling logic cleaner, more robust, and less prone to silent failures.