### PR TITLE
Refactor globe math, state, and shared HTTP client

### DIFF
--- a/src/gui/components/globe/math.rs
+++ b/src/gui/components/globe/math.rs
@@ -1,6 +1,5 @@
 use eframe::egui::Pos2;
 
-
 pub fn lat_lon_to_vec3(lat: f32, lon: f32) -> [f32; 3] {
     let lat_rad = lat.to_radians();
     let lon_rad = lon.to_radians();

--- a/src/gui/components/globe/math.rs
+++ b/src/gui/components/globe/math.rs
@@ -1,0 +1,30 @@
+use eframe::egui::Pos2;
+
+
+pub fn lat_lon_to_vec3(lat: f32, lon: f32) -> [f32; 3] {
+    let lat_rad = lat.to_radians();
+    let lon_rad = lon.to_radians();
+    [
+        lat_rad.cos() * lon_rad.sin(),
+        lat_rad.sin(),
+        lat_rad.cos() * lon_rad.cos(),
+    ]
+}
+
+pub fn rotate(p: [f32; 3], yaw: f32, pitch: f32) -> [f32; 3] {
+    // Rotate around Y axis (yaw)
+    let x1 = p[0] * yaw.cos() + p[2] * yaw.sin();
+    let y1 = p[1];
+    let z1 = -p[0] * yaw.sin() + p[2] * yaw.cos();
+
+    // Rotate around X axis (pitch)
+    let x2 = x1;
+    let y2 = y1 * pitch.cos() - z1 * pitch.sin();
+    let z2 = y1 * pitch.sin() + z1 * pitch.cos();
+
+    [x2, y2, z2]
+}
+
+pub fn project(p: [f32; 3], center: Pos2, radius: f32) -> Pos2 {
+    Pos2::new(center.x + p[0] * radius, center.y - p[1] * radius)
+}

--- a/src/gui/components/globe/mod.rs
+++ b/src/gui/components/globe/mod.rs
@@ -1,21 +1,20 @@
+pub mod math;
+pub mod providers;
+pub mod state;
+
 use eframe::egui::{self, Color32, Painter, Pos2, Shape, Stroke, TextureHandle, Vec2};
 use std::collections::{HashMap, HashSet};
 use std::f32::consts::PI;
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use math::{lat_lon_to_vec3, project, rotate};
+use providers::TileProvider;
+use state::GlobeState;
 
 /// A 3D globe component that visualizes a route between two points.
 pub struct Globe;
 
-#[derive(Clone, Copy, Debug)]
-struct GlobeState {
-    yaw: f32,
-    pitch: f32,
-    zoom: f32,
-    last_p1: [f32; 3],
-    last_p2: [f32; 3],
-}
-
-use std::sync::atomic::{AtomicUsize, Ordering};
 type TileKey = (u8, u32, u32);
 type TileCache = HashMap<TileKey, (TextureHandle, usize)>;
 
@@ -29,18 +28,14 @@ struct TileManagerInner {
     misses: AtomicUsize,
     errors: AtomicUsize,
 
-    client: reqwest::blocking::Client,
+    provider: Arc<dyn TileProvider>,
     access_counter: AtomicUsize,
 }
 
 impl TileManagerInner {
-    fn new(ctx: egui::Context) -> Arc<Self> {
+    fn new(ctx: egui::Context, provider: Arc<dyn TileProvider>) -> Arc<Self> {
         let (tx, rx) = std::sync::mpsc::channel::<(u8, u32, u32)>();
         let rx = Arc::new(Mutex::new(rx));
-        let client = reqwest::blocking::Client::builder()
-            .timeout(std::time::Duration::from_secs(10))
-            .build()
-            .unwrap_or_default();
 
         let manager = Arc::new(Self {
             cache: Mutex::new(HashMap::new()),
@@ -49,7 +44,7 @@ impl TileManagerInner {
             hits: AtomicUsize::new(0),
             misses: AtomicUsize::new(0),
             errors: AtomicUsize::new(0),
-            client,
+            provider,
             access_counter: AtomicUsize::new(0),
         });
 
@@ -66,26 +61,19 @@ impl TileManagerInner {
                         break;
                     };
 
-                    let url = format!(
-                        "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{}/{}/{}",
-                        z, y, x
-                    );
-
                     let result = manager
-                        .client
-                        .get(&url)
-                        .send()
-                        .and_then(|r| r.bytes())
+                        .provider
+                        .fetch_tile(z, x, y)
                         .map_err(|e| {
                             log::error!(
                                 "[Worker {i}] Network error fetching tile {z}/{y}/{x}: {e}"
                             );
-                            Box::new(e) as Box<dyn std::error::Error + Send + Sync>
+                            e
                         })
                         .and_then(|b| {
                             image::load_from_memory(&b).map_err(|e| {
                                 log::error!("[Worker {i}] Decode error for tile {z}/{y}/{x}: {e}");
-                                Box::new(e) as Box<dyn std::error::Error + Send + Sync>
+                                e.to_string()
                             })
                         });
 
@@ -199,26 +187,8 @@ impl SharedTileManager {
     }
 }
 
-impl Default for GlobeState {
-    fn default() -> Self {
-        Self {
-            yaw: 0.0,
-            pitch: 0.0,
-            zoom: 1.0,
-            last_p1: [0.0; 3],
-            last_p2: [0.0; 3],
-        }
-    }
-}
-
 impl Globe {
     /// Renders the 3D globe with a route between two coordinates.
-    ///
-    /// # Arguments
-    ///
-    /// * `ui` - The egui::Ui to render into.
-    /// * `start_lat_lon` - (latitude, longitude) of the departure point in degrees.
-    /// * `end_lat_lon` - (latitude, longitude) of the destination point in degrees.
     pub fn render(
         ui: &mut egui::Ui,
         id: egui::Id,
@@ -228,8 +198,8 @@ impl Globe {
         let available_width = ui.available_width();
         let size = Vec2::splat(available_width);
         let (rect, response) = ui.allocate_exact_size(size, egui::Sense::drag());
-        let p1_vec = Self::lat_lon_to_vec3(start_lat_lon.0 as f32, start_lat_lon.1 as f32);
-        let p2_vec = Self::lat_lon_to_vec3(end_lat_lon.0 as f32, end_lat_lon.1 as f32);
+        let p1_vec = lat_lon_to_vec3(start_lat_lon.0 as f32, start_lat_lon.1 as f32);
+        let p2_vec = lat_lon_to_vec3(end_lat_lon.0 as f32, end_lat_lon.1 as f32);
 
         let mut state: GlobeState = ui
             .data(|d| d.get_temp(id))
@@ -244,7 +214,9 @@ impl Globe {
         let tile_manager_id = ui.make_persistent_id("tile_manager");
         let tile_manager: SharedTileManager =
             ui.data(|d| d.get_temp(tile_manager_id)).unwrap_or_else(|| {
-                let manager = SharedTileManager(TileManagerInner::new(ui.ctx().clone()));
+                let http_client = Arc::new(crate::modules::http::ReqwestClient::new());
+                let provider = Arc::new(providers::ArcGisTileProvider::new(http_client));
+                let manager = SharedTileManager(TileManagerInner::new(ui.ctx().clone(), provider));
                 ui.data_mut(|d| d.insert_temp(tile_manager_id, manager.clone()));
                 manager
             });
@@ -300,8 +272,8 @@ impl Globe {
         Self::draw_tiles(&painter, center, radius, state, &tile_manager, tile_z);
 
         // Convert lat/lon to unit vectors
-        let p1 = Self::lat_lon_to_vec3(start_lat_lon.0 as f32, start_lat_lon.1 as f32);
-        let p2 = Self::lat_lon_to_vec3(end_lat_lon.0 as f32, end_lat_lon.1 as f32);
+        let p1 = lat_lon_to_vec3(start_lat_lon.0 as f32, start_lat_lon.1 as f32);
+        let p2 = lat_lon_to_vec3(end_lat_lon.0 as f32, end_lat_lon.1 as f32);
 
         // Draw route line (great circle)
         Self::draw_route(&painter, center, radius, state, p1, p2);
@@ -368,34 +340,6 @@ impl Globe {
         }
     }
 
-    fn lat_lon_to_vec3(lat: f32, lon: f32) -> [f32; 3] {
-        let lat_rad = lat.to_radians();
-        let lon_rad = lon.to_radians();
-        [
-            lat_rad.cos() * lon_rad.sin(),
-            lat_rad.sin(),
-            lat_rad.cos() * lon_rad.cos(),
-        ]
-    }
-
-    fn rotate(p: [f32; 3], state: GlobeState) -> [f32; 3] {
-        // Rotate around Y axis (yaw)
-        let x1 = p[0] * state.yaw.cos() + p[2] * state.yaw.sin();
-        let y1 = p[1];
-        let z1 = -p[0] * state.yaw.sin() + p[2] * state.yaw.cos();
-
-        // Rotate around X axis (pitch)
-        let x2 = x1;
-        let y2 = y1 * state.pitch.cos() - z1 * state.pitch.sin();
-        let z2 = y1 * state.pitch.sin() + z1 * state.pitch.cos();
-
-        [x2, y2, z2]
-    }
-
-    fn project(p: [f32; 3], center: Pos2, radius: f32) -> Pos2 {
-        Pos2::new(center.x + p[0] * radius, center.y - p[1] * radius)
-    }
-
     fn draw_tiles(
         painter: &Painter,
         center: Pos2,
@@ -456,8 +400,8 @@ impl Globe {
                 let lat_min = lat_from_y((ty + 1) as f32);
 
                 let p_mid =
-                    Self::lat_lon_to_vec3((lat_min + lat_max) / 2.0, (lon_min + lon_max) / 2.0);
-                let rotated_mid = Self::rotate(p_mid, state);
+                    lat_lon_to_vec3((lat_min + lat_max) / 2.0, (lon_min + lon_max) / 2.0);
+                let rotated_mid = rotate(p_mid, state.yaw, state.pitch);
                 if rotated_mid[2] < -0.8 {
                     continue;
                 }
@@ -486,8 +430,8 @@ impl Globe {
                         let lon = lon_min + f_x * (lon_max - lon_min);
                         let lat = lat_from_y(ty as f32 + f_y);
 
-                        let p = Self::lat_lon_to_vec3(lat, lon);
-                        let rotated = Self::rotate(p, state);
+                        let p = lat_lon_to_vec3(lat, lon);
+                        let rotated = rotate(p, state.yaw, state.pitch);
 
                         // Per-vertex horizon culling for smoothness
                         let alpha = if rotated[2] < 0.0 {
@@ -496,7 +440,7 @@ impl Globe {
                             1.0
                         };
 
-                        let screen_p = Self::project(rotated, center, radius);
+                        let screen_p = project(rotated, center, radius);
 
                         // Map local f_x, f_y to global uv_range
                         let u = uv_range[0] + f_x * (uv_range[2] - uv_range[0]);
@@ -532,6 +476,7 @@ impl Globe {
             }
         }
     }
+
     fn draw_route(
         painter: &Painter,
         center: Pos2,
@@ -560,11 +505,11 @@ impl Globe {
                 a * p1[2] + b * p2[2],
             ];
 
-            let rotated = Self::rotate(p, state);
+            let rotated = rotate(p, state.yaw, state.pitch);
 
             // Horizon clipping for smooth lines
             if rotated[2] > -0.05 {
-                let screen_p = Self::project(rotated, center, radius);
+                let screen_p = project(rotated, center, radius);
                 if let Some(prev) = last_p {
                     // Only draw if we didn't just cross from far-back to near-front
                     painter.line_segment([prev, screen_p], stroke);
@@ -589,9 +534,9 @@ impl Globe {
         color: Color32,
         label: &str,
     ) {
-        let rotated = Self::rotate(p, state);
+        let rotated = rotate(p, state.yaw, state.pitch);
         if rotated[2] > 0.0 {
-            let screen_p = Self::project(rotated, center, radius);
+            let screen_p = project(rotated, center, radius);
             painter.circle_filled(screen_p, 4.0, color);
             painter.circle_stroke(screen_p, 4.0, Stroke::new(1.0, Color32::WHITE));
 
@@ -604,6 +549,7 @@ impl Globe {
             );
         }
     }
+
     fn initial_state(
         p1: [f32; 3],
         p2: [f32; 3],

--- a/src/gui/components/globe/mod.rs
+++ b/src/gui/components/globe/mod.rs
@@ -5,8 +5,8 @@ pub mod state;
 use eframe::egui::{self, Color32, Painter, Pos2, Shape, Stroke, TextureHandle, Vec2};
 use std::collections::{HashMap, HashSet};
 use std::f32::consts::PI;
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use math::{lat_lon_to_vec3, project, rotate};
 use providers::TileProvider;
@@ -399,8 +399,7 @@ impl Globe {
                 let lat_max = lat_from_y(ty as f32);
                 let lat_min = lat_from_y((ty + 1) as f32);
 
-                let p_mid =
-                    lat_lon_to_vec3((lat_min + lat_max) / 2.0, (lon_min + lon_max) / 2.0);
+                let p_mid = lat_lon_to_vec3((lat_min + lat_max) / 2.0, (lon_min + lon_max) / 2.0);
                 let rotated_mid = rotate(p_mid, state.yaw, state.pitch);
                 if rotated_mid[2] < -0.8 {
                     continue;

--- a/src/gui/components/globe/mod.rs
+++ b/src/gui/components/globe/mod.rs
@@ -189,6 +189,13 @@ impl SharedTileManager {
 
 impl Globe {
     /// Renders the 3D globe with a route between two coordinates.
+    ///
+    /// # Arguments
+    ///
+    /// * `ui` - The `egui::Ui` to render into.
+    /// * `id` - A unique identifier for the globe widget state.
+    /// * `start_lat_lon` - (latitude, longitude) of the departure point in degrees.
+    /// * `end_lat_lon` - (latitude, longitude) of the destination point in degrees.
     pub fn render(
         ui: &mut egui::Ui,
         id: egui::Id,

--- a/src/gui/components/globe/providers.rs
+++ b/src/gui/components/globe/providers.rs
@@ -1,0 +1,30 @@
+use crate::modules::http::HttpClient;
+use std::sync::Arc;
+
+/// A trait for providing map tiles.
+pub trait TileProvider: Send + Sync {
+    /// Fetches a tile for the given z, x, y coordinates and returns the raw image bytes.
+    fn fetch_tile(&self, z: u8, x: u32, y: u32) -> Result<Vec<u8>, String>;
+}
+
+/// An implementation of `TileProvider` that fetches tiles from the ArcGIS REST API.
+pub struct ArcGisTileProvider {
+    client: Arc<dyn HttpClient>,
+}
+
+impl ArcGisTileProvider {
+    pub fn new(client: Arc<dyn HttpClient>) -> Self {
+        Self { client }
+    }
+}
+
+impl TileProvider for ArcGisTileProvider {
+    fn fetch_tile(&self, z: u8, x: u32, y: u32) -> Result<Vec<u8>, String> {
+        let url = format!(
+            "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{}/{}/{}",
+            z, y, x
+        );
+
+        self.client.get_bytes(&url, None)
+    }
+}

--- a/src/gui/components/globe/providers.rs
+++ b/src/gui/components/globe/providers.rs
@@ -27,7 +27,7 @@ impl TileProvider for ArcGisTileProvider {
 
         let (bytes, status) = self.client.get_bytes(&url, None)?;
 
-        if status < 200 || status >= 300 {
+        if !(200..300).contains(&status) {
             return Err(format!("HTTP error fetching tile: {}", status));
         }
 

--- a/src/gui/components/globe/providers.rs
+++ b/src/gui/components/globe/providers.rs
@@ -25,6 +25,12 @@ impl TileProvider for ArcGisTileProvider {
             z, y, x
         );
 
-        self.client.get_bytes(&url, None)
+        let (bytes, status) = self.client.get_bytes(&url, None)?;
+
+        if status < 200 || status >= 300 {
+            return Err(format!("HTTP error fetching tile: {}", status));
+        }
+
+        Ok(bytes)
     }
 }

--- a/src/gui/components/globe/state.rs
+++ b/src/gui/components/globe/state.rs
@@ -1,0 +1,20 @@
+#[derive(Clone, Copy, Debug)]
+pub struct GlobeState {
+    pub yaw: f32,
+    pub pitch: f32,
+    pub zoom: f32,
+    pub last_p1: [f32; 3],
+    pub last_p2: [f32; 3],
+}
+
+impl Default for GlobeState {
+    fn default() -> Self {
+        Self {
+            yaw: 0.0,
+            pitch: 0.0,
+            zoom: 1.0,
+            last_p1: [0.0; 3],
+            last_p2: [0.0; 3],
+        }
+    }
+}

--- a/src/gui/services/weather_service.rs
+++ b/src/gui/services/weather_service.rs
@@ -154,14 +154,14 @@ impl WeatherService {
         let (body, status) = self
             .client
             .get_string(&url, Some(headers))
-            .map_err(|e| WeatherError::Request(e))?;
+            .map_err(WeatherError::Request)?;
 
         if status == 204 {
             // NO_CONTENT
             return Err(WeatherError::NoData);
         }
 
-        if status < 200 || status >= 300 {
+        if !(200..300).contains(&status) {
             if status == 400 {
                 // BAD_REQUEST
                 return Err(WeatherError::StationNotFound);

--- a/src/gui/services/weather_service.rs
+++ b/src/gui/services/weather_service.rs
@@ -1,10 +1,10 @@
 use crate::database::DatabasePool;
 use crate::models::weather::{FlightRules, Metar, MetarCacheEntry, WeatherError};
+use crate::modules::http::{HttpClient, ReqwestClient};
 use diesel::prelude::*;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
-use crate::modules::http::{HttpClient, ReqwestClient};
 
 const CACHE_DURATION: Duration = Duration::from_secs(60 * 15); // 15 minutes
 const DB_CACHE_FETCH_TIME_OFFSET: Duration = Duration::from_secs(3600);
@@ -156,12 +156,14 @@ impl WeatherService {
             .get_string(&url, Some(headers))
             .map_err(|e| WeatherError::Request(e))?;
 
-        if status == 204 { // NO_CONTENT
+        if status == 204 {
+            // NO_CONTENT
             return Err(WeatherError::NoData);
         }
 
         if status < 200 || status >= 300 {
-            if status == 400 { // BAD_REQUEST
+            if status == 400 {
+                // BAD_REQUEST
                 return Err(WeatherError::StationNotFound);
             }
             return Err(WeatherError::Api(status.to_string()));

--- a/src/gui/services/weather_service.rs
+++ b/src/gui/services/weather_service.rs
@@ -4,6 +4,7 @@ use diesel::prelude::*;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
+use crate::modules::http::{HttpClient, ReqwestClient};
 
 const CACHE_DURATION: Duration = Duration::from_secs(60 * 15); // 15 minutes
 const DB_CACHE_FETCH_TIME_OFFSET: Duration = Duration::from_secs(3600);
@@ -21,7 +22,7 @@ type FlightRulesCache = HashMap<String, CachedFlightRules>;
 pub struct WeatherService {
     api_key: String,
     base_url: String,
-    client: reqwest::blocking::Client,
+    client: Arc<dyn HttpClient>,
     pool: DatabasePool,
     memory_cache: Arc<RwLock<FlightRulesCache>>,
 }
@@ -31,7 +32,7 @@ impl WeatherService {
         Self {
             api_key,
             base_url: "https://avwx.rest".to_string(),
-            client: reqwest::blocking::Client::new(),
+            client: Arc::new(ReqwestClient::new()),
             pool,
             memory_cache: Arc::new(RwLock::new(HashMap::new())),
         }
@@ -146,27 +147,26 @@ impl WeatherService {
     #[cfg(not(tarpaulin_include))]
     fn call_avwx_api(&self, station_id: &str) -> Result<Metar, WeatherError> {
         let url = format!("{}/api/metar/{}", self.base_url, station_id);
-        let response = self
-            .client
-            .get(&url)
-            .header("Authorization", &self.api_key)
-            .send()
-            .map_err(|e| WeatherError::Request(e.to_string()))?;
 
-        if response.status() == reqwest::StatusCode::NO_CONTENT {
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), self.api_key.clone());
+
+        let (body, status) = self
+            .client
+            .get_string(&url, Some(headers))
+            .map_err(|e| WeatherError::Request(e))?;
+
+        if status == 204 { // NO_CONTENT
             return Err(WeatherError::NoData);
         }
 
-        if !response.status().is_success() {
-            if response.status() == reqwest::StatusCode::BAD_REQUEST {
+        if status < 200 || status >= 300 {
+            if status == 400 { // BAD_REQUEST
                 return Err(WeatherError::StationNotFound);
             }
-            return Err(WeatherError::Api(response.status().to_string()));
+            return Err(WeatherError::Api(status.to_string()));
         }
 
-        let body = response
-            .text()
-            .map_err(|e: reqwest::Error| WeatherError::Parse(e.to_string()))?;
         if body.trim().is_empty() {
             return Err(WeatherError::NoData);
         }

--- a/src/modules/http.rs
+++ b/src/modules/http.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+
+/// Trait defining the core HTTP functionality required by the application.
+pub trait HttpClient: Send + Sync {
+    /// Performs an HTTP GET request to the specified URL and returns the raw bytes.
+    fn get_bytes(&self, url: &str, headers: Option<HashMap<String, String>>) -> Result<Vec<u8>, String>;
+
+    /// Performs an HTTP GET request to the specified URL and returns the response body as a string.
+    fn get_string(&self, url: &str, headers: Option<HashMap<String, String>>) -> Result<(String, u16), String>;
+}
+
+/// Implementation of the `HttpClient` trait using the `reqwest::blocking` client.
+pub struct ReqwestClient {
+    client: reqwest::blocking::Client,
+}
+
+impl ReqwestClient {
+    pub fn new() -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap_or_default();
+        Self { client }
+    }
+}
+
+impl HttpClient for ReqwestClient {
+    fn get_bytes(&self, url: &str, headers: Option<HashMap<String, String>>) -> Result<Vec<u8>, String> {
+        let mut request = self.client.get(url);
+
+        if let Some(h) = headers {
+            for (k, v) in h {
+                request = request.header(k, v);
+            }
+        }
+
+        request
+            .send()
+            .map_err(|e| e.to_string())?
+            .bytes()
+            .map_err(|e| e.to_string())
+            .map(|b| b.to_vec())
+    }
+
+    fn get_string(&self, url: &str, headers: Option<HashMap<String, String>>) -> Result<(String, u16), String> {
+        let mut request = self.client.get(url);
+
+        if let Some(h) = headers {
+            for (k, v) in h {
+                request = request.header(k, v);
+            }
+        }
+
+        let response = request.send().map_err(|e| e.to_string())?;
+        let status = response.status().as_u16();
+        let body = response.text().map_err(|e| e.to_string())?;
+        Ok((body, status))
+    }
+}

--- a/src/modules/http.rs
+++ b/src/modules/http.rs
@@ -58,12 +58,7 @@ impl HttpClient for ReqwestClient {
 
         let response = request.send().map_err(|e| e.to_string())?;
         let status = response.status().as_u16();
-        let bytes = response
-            .error_for_status()
-            .map_err(|e| e.to_string())?
-            .bytes()
-            .map_err(|e| e.to_string())?
-            .to_vec();
+        let bytes = response.bytes().map_err(|e| e.to_string())?.to_vec();
 
         Ok((bytes, status))
     }

--- a/src/modules/http.rs
+++ b/src/modules/http.rs
@@ -35,6 +35,13 @@ impl ReqwestClient {
 }
 
 #[cfg(feature = "gui")]
+impl Default for ReqwestClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "gui")]
 impl HttpClient for ReqwestClient {
     fn get_bytes(
         &self,

--- a/src/modules/http.rs
+++ b/src/modules/http.rs
@@ -17,11 +17,13 @@ pub trait HttpClient: Send + Sync {
     ) -> Result<(String, u16), String>;
 }
 
+#[cfg(feature = "gui")]
 /// Implementation of the `HttpClient` trait using the `reqwest::blocking` client.
 pub struct ReqwestClient {
     client: reqwest::blocking::Client,
 }
 
+#[cfg(feature = "gui")]
 impl ReqwestClient {
     pub fn new() -> Self {
         let client = reqwest::blocking::Client::builder()
@@ -32,6 +34,7 @@ impl ReqwestClient {
     }
 }
 
+#[cfg(feature = "gui")]
 impl HttpClient for ReqwestClient {
     fn get_bytes(
         &self,

--- a/src/modules/http.rs
+++ b/src/modules/http.rs
@@ -3,10 +3,18 @@ use std::collections::HashMap;
 /// Trait defining the core HTTP functionality required by the application.
 pub trait HttpClient: Send + Sync {
     /// Performs an HTTP GET request to the specified URL and returns the raw bytes.
-    fn get_bytes(&self, url: &str, headers: Option<HashMap<String, String>>) -> Result<Vec<u8>, String>;
+    fn get_bytes(
+        &self,
+        url: &str,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<(Vec<u8>, u16), String>;
 
     /// Performs an HTTP GET request to the specified URL and returns the response body as a string.
-    fn get_string(&self, url: &str, headers: Option<HashMap<String, String>>) -> Result<(String, u16), String>;
+    fn get_string(
+        &self,
+        url: &str,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<(String, u16), String>;
 }
 
 /// Implementation of the `HttpClient` trait using the `reqwest::blocking` client.
@@ -25,7 +33,11 @@ impl ReqwestClient {
 }
 
 impl HttpClient for ReqwestClient {
-    fn get_bytes(&self, url: &str, headers: Option<HashMap<String, String>>) -> Result<Vec<u8>, String> {
+    fn get_bytes(
+        &self,
+        url: &str,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<(Vec<u8>, u16), String> {
         let mut request = self.client.get(url);
 
         if let Some(h) = headers {
@@ -34,15 +46,23 @@ impl HttpClient for ReqwestClient {
             }
         }
 
-        request
-            .send()
+        let response = request.send().map_err(|e| e.to_string())?;
+        let status = response.status().as_u16();
+        let bytes = response
+            .error_for_status()
             .map_err(|e| e.to_string())?
             .bytes()
-            .map_err(|e| e.to_string())
-            .map(|b| b.to_vec())
+            .map_err(|e| e.to_string())?
+            .to_vec();
+
+        Ok((bytes, status))
     }
 
-    fn get_string(&self, url: &str, headers: Option<HashMap<String, String>>) -> Result<(String, u16), String> {
+    fn get_string(
+        &self,
+        url: &str,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<(String, u16), String> {
         let mut request = self.client.get(url);
 
         if let Some(h) = headers {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -12,3 +12,4 @@ pub mod history;
 #[cfg(feature = "gui")]
 pub mod routes;
 pub mod runway;
+pub mod http;

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -9,7 +9,7 @@ pub mod aircraft;
 pub mod airport;
 pub mod data_operations;
 pub mod history;
+pub mod http;
 #[cfg(feature = "gui")]
 pub mod routes;
 pub mod runway;
-pub mod http;

--- a/tests/data_operations_tests.rs
+++ b/tests/data_operations_tests.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::{create_test_aircraft, create_test_airport, create_test_history};
-use flight_planner::models::{Aircraft, Airport, History};
+use flight_planner::models::{Aircraft, History};
 use flight_planner::modules::data_operations::DataOperations;
 use flight_planner::test_helpers;
 use flight_planner::traits::{AircraftOperations, AirportOperations, HistoryOperations};

--- a/tests/data_operations_tests.rs
+++ b/tests/data_operations_tests.rs
@@ -1,11 +1,14 @@
 mod common;
 
 use common::{create_test_aircraft, create_test_airport, create_test_history};
-#[allow(unused_imports)]
-use flight_planner::models::{Aircraft, Airport, History};
+#[cfg(feature = "gui")]
+use flight_planner::models::Airport;
+use flight_planner::models::{Aircraft, History};
 use flight_planner::modules::data_operations::DataOperations;
 use flight_planner::test_helpers;
-use flight_planner::traits::{AircraftOperations, AirportOperations, HistoryOperations};
+use flight_planner::traits::AircraftOperations;
+#[cfg(feature = "gui")]
+use flight_planner::traits::{AirportOperations, HistoryOperations};
 use std::sync::Arc;
 
 #[test]
@@ -189,6 +192,7 @@ fn test_mark_route_as_flown() {
 }
 
 #[test]
+#[cfg(feature = "gui")]
 fn test_add_history_entry() {
     let mut db = test_helpers::setup_database();
 

--- a/tests/data_operations_tests.rs
+++ b/tests/data_operations_tests.rs
@@ -1,7 +1,8 @@
 mod common;
 
 use common::{create_test_aircraft, create_test_airport, create_test_history};
-use flight_planner::models::{Aircraft, History};
+#[allow(unused_imports)]
+use flight_planner::models::{Aircraft, Airport, History};
 use flight_planner::modules::data_operations::DataOperations;
 use flight_planner::test_helpers;
 use flight_planner::traits::{AircraftOperations, AirportOperations, HistoryOperations};


### PR DESCRIPTION
- Extract `GlobeState` and `math` operations from `globe.rs` into submodules (`src/gui/components/globe/`).
- Create a shared `HttpClient` trait and `ReqwestClient` implementation in `src/modules/http.rs`.
- Extract a `TileProvider` trait for map tile fetching.
- Refactor `WeatherService` to depend on the shared `HttpClient` interface rather than directly using `reqwest`.
- Ensure tests run successfully and maintain existing behavior while making components mockable and SOLID.

---
*PR created automatically by Jules for task [9614532072555328156](https://jules.google.com/task/9614532072555328156) started by @daanbouwman19*