### PR TITLE
Optimize globe renderer: basis caching, route pre-computation, LRU ti…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,7 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "log4rs",
+ "lru",
  "r2d2",
  "rand 0.10.1",
  "rayon",
@@ -2181,6 +2182,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2901,6 +2904,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ eframe = { version = "^0.34.2", features = ["wgpu"], optional = true }
 egui = { version = "^0.34.1", optional = true }
 egui_extras = { version = "^0.34.2", optional = true }
 image = { version = "^0.25", optional = true }
+lru = { version = "0.12", optional = true }
 rayon = { version = "^1.12", optional = true }
 reqwest = { version = "^0.13", features = ["blocking", "json"], optional = true }
 rstar = { version = "^0.12", optional = true }
@@ -67,8 +68,8 @@ tokio = { version = "^1.52", features = ["full"] }
 
 [features]
 default = ["gui"]
-gui = ["dep:egui", "dep:egui_extras", "dep:eframe", "dep:image", "dep:rayon", "dep:reqwest", "dep:rstar", "dep:serde_json", "dep:dotenvy"]
-web = ["dep:egui", "dep:egui_extras", "dep:eframe", "dep:image", "dep:serde_json", "dep:rstar"]
+gui = ["dep:egui", "dep:egui_extras", "dep:eframe", "dep:image", "dep:lru", "dep:rayon", "dep:reqwest", "dep:rstar", "dep:serde_json", "dep:dotenvy"]
+web = ["dep:egui", "dep:egui_extras", "dep:eframe", "dep:image", "dep:lru", "dep:serde_json", "dep:rstar"]
 server = ["dep:axum", "dep:tokio", "dep:tower", "dep:tower-http", "dep:serde_json"]
 
 [[bin]]

--- a/src/gui/components/globe/camera.rs
+++ b/src/gui/components/globe/camera.rs
@@ -102,7 +102,10 @@ pub struct CameraBasis {
     up: Vec3,
     look: Vec3,
     position: Vec3,
-    altitude: f32,
+    /// position / (1 + altitude) — facing_value_fast reduces to a single dot product.
+    facing_unit: Vec3,
+    /// position.dot(position) - 1.0 — reused in every ray-sphere intersection test.
+    c_val: f32,
 }
 
 /// Rotate a world point into camera space using a pre-computed basis.
@@ -112,11 +115,10 @@ pub fn rotate_fast(basis: &CameraBasis, w: [f32; 3]) -> [f32; 3] {
     [d.dot(basis.right), d.dot(basis.up), d.dot(basis.look)]
 }
 
-/// Back-face culling value using a pre-computed basis.
+/// Back-face culling value using a pre-computed basis (single dot product).
 #[inline]
 pub fn facing_value_fast(basis: &CameraBasis, w: [f32; 3]) -> f32 {
-    let r = 1.0 + basis.altitude;
-    Vec3::from(w).dot(basis.position) / r
+    Vec3::from(w).dot(basis.facing_unit)
 }
 
 // ---------------------------------------------------------------------------
@@ -200,12 +202,14 @@ impl Camera {
     /// recomputing sin/cos once per vertex.
     pub fn compute_basis(&self) -> CameraBasis {
         let (right, up, look, position) = self.basis();
+        let r = 1.0 + self.altitude;
         CameraBasis {
             right,
             up,
             look,
             position,
-            altitude: self.altitude,
+            facing_unit: position * (1.0 / r),
+            c_val: position.dot(position) - 1.0,
         }
     }
 
@@ -374,9 +378,8 @@ impl Camera {
 
         let a = dir.dot(dir);
         let b = position.dot(dir);
-        let c_val = position.dot(position) - 1.0;
 
-        let disc = b * b - a * c_val;
+        let disc = b * b - a * basis.c_val;
         if disc < 0.0 {
             return None;
         }

--- a/src/gui/components/globe/camera.rs
+++ b/src/gui/components/globe/camera.rs
@@ -19,10 +19,12 @@ pub const TILE_PX: f32 = 256.0;
 struct Vec3(f32, f32, f32);
 
 impl Vec3 {
+    #[inline]
     fn dot(self, o: Vec3) -> f32 {
         self.0 * o.0 + self.1 * o.1 + self.2 * o.2
     }
 
+    #[inline]
     fn cross(self, o: Vec3) -> Vec3 {
         Vec3(
             self.1 * o.2 - self.2 * o.1,
@@ -31,6 +33,7 @@ impl Vec3 {
         )
     }
 
+    #[inline]
     fn normalize(self) -> Vec3 {
         let len = self.dot(self).sqrt();
         if len < 1e-10 {
@@ -42,12 +45,14 @@ impl Vec3 {
 }
 
 impl From<[f32; 3]> for Vec3 {
+    #[inline]
     fn from(a: [f32; 3]) -> Vec3 {
         Vec3(a[0], a[1], a[2])
     }
 }
 
 impl From<Vec3> for [f32; 3] {
+    #[inline]
     fn from(v: Vec3) -> [f32; 3] {
         [v.0, v.1, v.2]
     }
@@ -55,6 +60,7 @@ impl From<Vec3> for [f32; 3] {
 
 impl Add for Vec3 {
     type Output = Vec3;
+    #[inline]
     fn add(self, o: Vec3) -> Vec3 {
         Vec3(self.0 + o.0, self.1 + o.1, self.2 + o.2)
     }
@@ -62,6 +68,7 @@ impl Add for Vec3 {
 
 impl Sub for Vec3 {
     type Output = Vec3;
+    #[inline]
     fn sub(self, o: Vec3) -> Vec3 {
         Vec3(self.0 - o.0, self.1 - o.1, self.2 - o.2)
     }
@@ -69,6 +76,7 @@ impl Sub for Vec3 {
 
 impl Mul<f32> for Vec3 {
     type Output = Vec3;
+    #[inline]
     fn mul(self, s: f32) -> Vec3 {
         Vec3(self.0 * s, self.1 * s, self.2 * s)
     }
@@ -76,9 +84,39 @@ impl Mul<f32> for Vec3 {
 
 impl Neg for Vec3 {
     type Output = Vec3;
+    #[inline]
     fn neg(self) -> Vec3 {
         Vec3(-self.0, -self.1, -self.2)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Pre-computed camera basis — amortizes basis() across all per-vertex calls.
+// ---------------------------------------------------------------------------
+
+/// Cached camera basis vectors, valid for one camera state.
+/// Compute once per frame with `Camera::compute_basis()`, then pass to
+/// `rotate_fast` / `facing_value_fast` to avoid redundant sin/cos per vertex.
+pub struct CameraBasis {
+    right: Vec3,
+    up: Vec3,
+    look: Vec3,
+    position: Vec3,
+    altitude: f32,
+}
+
+/// Rotate a world point into camera space using a pre-computed basis.
+#[inline]
+pub fn rotate_fast(basis: &CameraBasis, w: [f32; 3]) -> [f32; 3] {
+    let d = Vec3::from(w) - basis.position;
+    [d.dot(basis.right), d.dot(basis.up), d.dot(basis.look)]
+}
+
+/// Back-face culling value using a pre-computed basis.
+#[inline]
+pub fn facing_value_fast(basis: &CameraBasis, w: [f32; 3]) -> f32 {
+    let r = 1.0 + basis.altitude;
+    Vec3::from(w).dot(basis.position) / r
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +193,20 @@ impl Camera {
         let position = n * (1.0 + t * ct) + up_base * (-t * st);
 
         (right, up, look, position)
+    }
+
+    /// Compute and cache the camera basis vectors for this frame.
+    /// Pass the result to `rotate_fast` / `facing_value_fast` to avoid
+    /// recomputing sin/cos once per vertex.
+    pub fn compute_basis(&self) -> CameraBasis {
+        let (right, up, look, position) = self.basis();
+        CameraBasis {
+            right,
+            up,
+            look,
+            position,
+            altitude: self.altitude,
+        }
     }
 
     /// Focal length in pixels: half the viewport height divided by tan(fov_y/2).
@@ -305,8 +357,39 @@ impl Camera {
         }
     }
 
+    /// Ray–sphere intersection using a pre-computed basis (avoids recomputing basis per sample).
+    fn screen_to_world_fast(
+        &self,
+        cursor: Pos2,
+        viewport: Rect,
+        basis: &CameraBasis,
+    ) -> Option<[f32; 3]> {
+        let f = self.focal_pixels(viewport.height());
+        let c = viewport.center();
+        let ix = (cursor.x - c.x) / f;
+        let iy = -(cursor.y - c.y) / f;
+
+        let dir = basis.right * ix + basis.up * iy + basis.look;
+        let position = basis.position;
+
+        let a = dir.dot(dir);
+        let b = position.dot(dir);
+        let c_val = position.dot(position) - 1.0;
+
+        let disc = b * b - a * c_val;
+        if disc < 0.0 {
+            return None;
+        }
+        let t = (-b - disc.sqrt()) / a;
+        if t < 0.0 {
+            return None;
+        }
+        Some((position + dir * t).into())
+    }
+
     /// Approximate lat/lon bounds visible from the current camera.
     pub fn visible_lat_lon_bounds(&self, viewport: Rect) -> LatLonBounds {
+        let basis = self.compute_basis();
         let center = viewport.center();
         let f = self.focal_pixels(viewport.height());
         let r = 1.0 + self.altitude;
@@ -351,7 +434,7 @@ impl Camera {
         let mut lons: Vec<f32> = Vec::with_capacity(points.len());
 
         for p in &points {
-            if let Some(w) = self.screen_to_world(*p, viewport) {
+            if let Some(w) = self.screen_to_world_fast(*p, viewport, &basis) {
                 let (lat, lon) = world_to_lat_lon(w);
                 lats.push(lat);
                 lons.push(lon);
@@ -650,6 +733,43 @@ mod tests {
             assert!(
                 diff > 1.0,
                 "bearing rotation should move screen position of north point: diff={diff}",
+            );
+        }
+    }
+
+    /// rotate_fast and facing_value_fast should match the non-fast versions.
+    #[test]
+    fn fast_variants_match_slow() {
+        let camera = Camera {
+            center_lat: 15.0,
+            center_lon: -30.0,
+            altitude: 1.5,
+            bearing: 0.3,
+            tilt: 0.2,
+            fov_y: DEFAULT_FOV_Y,
+        };
+        let basis = camera.compute_basis();
+        let pts = [
+            lat_lon_to_world(0.0, 0.0),
+            lat_lon_to_world(15.0, -30.0),
+            lat_lon_to_world(-45.0, 90.0),
+        ];
+        for w in pts {
+            let r_slow = camera.rotate(w);
+            let r_fast = rotate_fast(&basis, w);
+            for i in 0..3 {
+                assert!(
+                    (r_slow[i] - r_fast[i]).abs() < 1e-5,
+                    "rotate_fast mismatch at index {i}: slow={}, fast={}",
+                    r_slow[i],
+                    r_fast[i]
+                );
+            }
+            let fv_slow = camera.facing_value(w);
+            let fv_fast = facing_value_fast(&basis, w);
+            assert!(
+                (fv_slow - fv_fast).abs() < 1e-5,
+                "facing_value_fast mismatch: slow={fv_slow}, fast={fv_fast}",
             );
         }
     }

--- a/src/gui/components/globe/mod.rs
+++ b/src/gui/components/globe/mod.rs
@@ -9,7 +9,7 @@ pub mod tile_manager;
 use eframe::egui::{self, Color32, Vec2};
 
 use camera::{Camera, DEFAULT_FOV_Y, MAX_DISTANCE, MIN_DISTANCE};
-use state::{GlobeState, MAX_ALTITUDE, MIN_ALTITUDE};
+use state::{GlobeState, MAX_ALTITUDE, MAX_ROUTE_STEPS, MIN_ALTITUDE};
 use tile_manager::SharedTileManager;
 
 pub struct Globe;
@@ -56,11 +56,20 @@ impl Globe {
             tile_manager.trigger_fetch(z, x, y);
         }
 
+        // Compute camera basis once for all per-vertex operations this frame.
+        let basis = camera.compute_basis();
+
+        let route_pts: &[[f32; 3]] = if state.route_steps > 0 {
+            &state.route_points[..=state.route_steps]
+        } else {
+            &[]
+        };
+
         let painter = ui.painter_at(rect);
-        renderer::draw_tiles(&painter, camera, rect, &tiles, lod, &tile_manager);
-        renderer::draw_route(&painter, camera, rect, p1, p2);
-        renderer::draw_point(&painter, camera, rect, p1, Color32::GREEN, "DEP");
-        renderer::draw_point(&painter, camera, rect, p2, Color32::RED, "DEST");
+        renderer::draw_tiles(&painter, camera, &basis, rect, &tiles, lod, &tile_manager);
+        renderer::draw_route(&painter, camera, &basis, rect, route_pts);
+        renderer::draw_point(&painter, camera, &basis, rect, p1, Color32::GREEN, "DEP");
+        renderer::draw_point(&painter, camera, &basis, rect, p2, Color32::RED, "DEST");
         renderer::draw_globe_outline(&painter, camera, rect);
 
         let time = ui.input(|i| i.time);
@@ -86,6 +95,28 @@ impl Globe {
     }
 }
 
+fn compute_route_points(p1: [f32; 3], p2: [f32; 3]) -> ([[f32; 3]; 101], usize) {
+    let dot = p1[0] * p2[0] + p1[1] * p2[1] + p1[2] * p2[2];
+    let theta = dot.clamp(-1.0, 1.0).acos();
+    if theta < 0.001 {
+        return ([[0.0; 3]; 101], 0);
+    }
+    let steps = (theta.to_degrees() as usize).clamp(10, MAX_ROUTE_STEPS);
+    let sin_theta = theta.sin();
+    let mut points = [[0.0f32; 3]; 101];
+    for i in 0..=steps {
+        let f = i as f32 / steps as f32;
+        let a = ((1.0 - f) * theta).sin() / sin_theta;
+        let b = (f * theta).sin() / sin_theta;
+        points[i] = [
+            a * p1[0] + b * p2[0],
+            a * p1[1] + b * p2[1],
+            a * p1[2] + b * p2[2],
+        ];
+    }
+    (points, steps)
+}
+
 fn initial_state(
     p1: [f32; 3],
     p2: [f32; 3],
@@ -107,6 +138,8 @@ fn initial_state(
     let avg_lat = ((start_lat_lon.0 + end_lat_lon.0) / 2.0) as f32;
     let avg_lon = ((start_lat_lon.1 + end_lat_lon.1) / 2.0) as f32;
 
+    let (route_points, route_steps) = compute_route_points(p1, p2);
+
     GlobeState {
         camera: Camera {
             center_lat: avg_lat,
@@ -119,5 +152,7 @@ fn initial_state(
         last_p1: p1,
         last_p2: p2,
         drag: None,
+        route_points,
+        route_steps,
     }
 }

--- a/src/gui/components/globe/mod.rs
+++ b/src/gui/components/globe/mod.rs
@@ -95,15 +95,15 @@ impl Globe {
     }
 }
 
-fn compute_route_points(p1: [f32; 3], p2: [f32; 3]) -> ([[f32; 3]; 101], usize) {
+fn compute_route_points(p1: [f32; 3], p2: [f32; 3]) -> ([[f32; 3]; MAX_ROUTE_STEPS + 1], usize) {
     let dot = p1[0] * p2[0] + p1[1] * p2[1] + p1[2] * p2[2];
     let theta = dot.clamp(-1.0, 1.0).acos();
     if theta < 0.001 {
-        return ([[0.0; 3]; 101], 0);
+        return ([[0.0; 3]; MAX_ROUTE_STEPS + 1], 0);
     }
     let steps = (theta.to_degrees() as usize).clamp(10, MAX_ROUTE_STEPS);
     let sin_theta = theta.sin();
-    let mut points = [[0.0f32; 3]; 101];
+    let mut points = [[0.0f32; 3]; MAX_ROUTE_STEPS + 1];
     for i in 0..=steps {
         let f = i as f32 / steps as f32;
         let a = ((1.0 - f) * theta).sin() / sin_theta;

--- a/src/gui/components/globe/mod.rs
+++ b/src/gui/components/globe/mod.rs
@@ -104,11 +104,11 @@ fn compute_route_points(p1: [f32; 3], p2: [f32; 3]) -> ([[f32; 3]; MAX_ROUTE_STE
     let steps = (theta.to_degrees() as usize).clamp(10, MAX_ROUTE_STEPS);
     let sin_theta = theta.sin();
     let mut points = [[0.0f32; 3]; MAX_ROUTE_STEPS + 1];
-    for i in 0..=steps {
+    for (i, point) in points.iter_mut().take(steps + 1).enumerate() {
         let f = i as f32 / steps as f32;
         let a = ((1.0 - f) * theta).sin() / sin_theta;
         let b = (f * theta).sin() / sin_theta;
-        points[i] = [
+        *point = [
             a * p1[0] + b * p2[0],
             a * p1[1] + b * p2[1],
             a * p1[2] + b * p2[2],

--- a/src/gui/components/globe/renderer.rs
+++ b/src/gui/components/globe/renderer.rs
@@ -1,18 +1,30 @@
 use eframe::egui::{self, Color32, Painter, Pos2, Rect, Shape, Stroke, Vec2};
 
-use super::camera::{Camera, lat_lon_to_world, tile_y_to_lat};
+use super::camera::{Camera, CameraBasis, facing_value_fast, lat_lon_to_world, rotate_fast, tile_y_to_lat};
 use super::tile_grid::VisibleTile;
 use super::tile_manager::{SharedTileManager, TileStats};
 
-const TILE_SUBSTEPS: usize = 6;
+const TILE_SUBSTEPS_MAX: usize = 6;
 const ATMOSPHERE_ALPHA: u8 = 30;
 const GLOBE_OUTLINE_WIDTH: f32 = 2.0;
 const ROUTE_STROKE_WIDTH: f32 = 3.0;
 const POINT_RADIUS: f32 = 4.0;
 
+/// Substep count scales with LOD: zoomed-out tiles are tiny on screen and need
+/// fewer curve samples; close-up tiles need more to round the earth smoothly.
+#[inline]
+fn substeps_for_lod(lod: u8) -> usize {
+    match lod {
+        0..=3 => 2,
+        4..=6 => 4,
+        _ => TILE_SUBSTEPS_MAX,
+    }
+}
+
 pub fn draw_tiles(
     painter: &Painter,
     camera: &Camera,
+    basis: &CameraBasis,
     viewport: Rect,
     tiles: &[VisibleTile],
     lod: u8,
@@ -21,6 +33,8 @@ pub fn draw_tiles(
     let num_tiles = 1u32 << lod;
     let num_tiles_f = num_tiles as f32;
     let threshold = camera.cull_threshold();
+    let substeps = substeps_for_lod(lod);
+    let stride = substeps + 1;
 
     for tile in tiles {
         let Some((texture, uv)) = manager.get_best_tile(lod, tile.x, tile.y) else {
@@ -28,20 +42,19 @@ pub fn draw_tiles(
         };
 
         let mut mesh = egui::Mesh::with_texture(texture.id());
-        let stride = TILE_SUBSTEPS + 1;
         let mut any_behind = false;
 
-        for sy in 0..=TILE_SUBSTEPS {
-            for sx in 0..=TILE_SUBSTEPS {
-                let f_x = sx as f32 / TILE_SUBSTEPS as f32;
-                let f_y = sy as f32 / TILE_SUBSTEPS as f32;
+        for sy in 0..=substeps {
+            for sx in 0..=substeps {
+                let f_x = sx as f32 / substeps as f32;
+                let f_y = sy as f32 / substeps as f32;
 
                 let lon = tile.lon_min + f_x * (tile.lon_max - tile.lon_min);
                 let lat = tile_y_to_lat(tile.y as f32 + f_y, num_tiles_f);
 
                 let w = lat_lon_to_world(lat, lon);
-                let alpha = ((camera.facing_value(w) - threshold) * 5.0).clamp(0.0, 1.0);
-                let rotated = camera.rotate(w);
+                let alpha = ((facing_value_fast(basis, w) - threshold) * 5.0).clamp(0.0, 1.0);
+                let rotated = rotate_fast(basis, w);
 
                 let Some(screen_p) = camera.project(rotated, viewport) else {
                     any_behind = true;
@@ -66,8 +79,8 @@ pub fn draw_tiles(
             continue;
         }
 
-        for sy in 0..TILE_SUBSTEPS {
-            for sx in 0..TILE_SUBSTEPS {
+        for sy in 0..substeps {
+            for sx in 0..substeps {
                 let i = sy * stride + sx;
                 mesh.indices.extend_from_slice(&[
                     i as u32,
@@ -83,31 +96,26 @@ pub fn draw_tiles(
     }
 }
 
-pub fn draw_route(painter: &Painter, camera: &Camera, viewport: Rect, p1: [f32; 3], p2: [f32; 3]) {
-    let dot = p1[0] * p2[0] + p1[1] * p2[1] + p1[2] * p2[2];
-    let theta = dot.clamp(-1.0, 1.0).acos();
-    if theta < 0.001 {
+/// Draw the great-circle route from pre-computed slerp points.
+/// `route_points` must be empty when there is no route (theta < threshold).
+pub fn draw_route(
+    painter: &Painter,
+    camera: &Camera,
+    basis: &CameraBasis,
+    viewport: Rect,
+    route_points: &[[f32; 3]],
+) {
+    if route_points.is_empty() {
         return;
     }
 
     let threshold = camera.cull_threshold();
-    let steps = (theta.to_degrees() as usize).clamp(10, 100);
     let mut last_p: Option<Pos2> = None;
     let stroke = Stroke::new(ROUTE_STROKE_WIDTH, Color32::from_rgb(255, 200, 0));
-    let sin_theta = theta.sin();
 
-    for i in 0..=steps {
-        let f = i as f32 / steps as f32;
-        let a = ((1.0 - f) * theta).sin() / sin_theta;
-        let b = (f * theta).sin() / sin_theta;
-        let p = [
-            a * p1[0] + b * p2[0],
-            a * p1[1] + b * p2[1],
-            a * p1[2] + b * p2[2],
-        ];
-
-        if camera.facing_value(p) > threshold {
-            let rotated = camera.rotate(p);
+    for &p in route_points {
+        if facing_value_fast(basis, p) > threshold {
+            let rotated = rotate_fast(basis, p);
             if let Some(screen_p) = camera.project(rotated, viewport) {
                 if let Some(prev) = last_p {
                     painter.line_segment([prev, screen_p], stroke);
@@ -125,16 +133,17 @@ pub fn draw_route(painter: &Painter, camera: &Camera, viewport: Rect, p1: [f32; 
 pub fn draw_point(
     painter: &Painter,
     camera: &Camera,
+    basis: &CameraBasis,
     viewport: Rect,
     p: [f32; 3],
     color: Color32,
     label: &str,
 ) {
     let threshold = camera.cull_threshold();
-    if camera.facing_value(p) <= threshold {
+    if facing_value_fast(basis, p) <= threshold {
         return;
     }
-    let rotated = camera.rotate(p);
+    let rotated = rotate_fast(basis, p);
     let Some(screen_p) = camera.project(rotated, viewport) else {
         return;
     };

--- a/src/gui/components/globe/renderer.rs
+++ b/src/gui/components/globe/renderer.rs
@@ -1,6 +1,8 @@
 use eframe::egui::{self, Color32, Painter, Pos2, Rect, Shape, Stroke, Vec2};
 
-use super::camera::{Camera, CameraBasis, facing_value_fast, lat_lon_to_world, rotate_fast, tile_y_to_lat};
+use super::camera::{
+    Camera, CameraBasis, facing_value_fast, lat_lon_to_world, rotate_fast, tile_y_to_lat,
+};
 use super::tile_grid::VisibleTile;
 use super::tile_manager::{SharedTileManager, TileStats};
 

--- a/src/gui/components/globe/state.rs
+++ b/src/gui/components/globe/state.rs
@@ -29,7 +29,7 @@ pub struct GlobeState {
     pub drag: Option<Drag>,
     /// Pre-computed great-circle slerp points between last_p1 and last_p2.
     /// Valid indices: `0..=route_steps`. `route_steps == 0` means no route.
-    pub route_points: [[f32; 3]; 101],
+    pub route_points: [[f32; 3]; MAX_ROUTE_STEPS + 1],
     pub route_steps: usize,
 }
 
@@ -47,7 +47,7 @@ impl Default for GlobeState {
             last_p1: [0.0; 3],
             last_p2: [0.0; 3],
             drag: None,
-            route_points: [[0.0; 3]; 101],
+            route_points: [[0.0; 3]; MAX_ROUTE_STEPS + 1],
             route_steps: 0,
         }
     }

--- a/src/gui/components/globe/state.rs
+++ b/src/gui/components/globe/state.rs
@@ -5,6 +5,9 @@ pub const MIN_ALTITUDE: f32 = MIN_DISTANCE - 1.0;
 /// Maximum altitude (whole globe with breathing room).
 pub const MAX_ALTITUDE: f32 = MAX_DISTANCE - 1.0;
 
+/// Maximum slerp steps for a route (theta ≤ 100°).
+pub const MAX_ROUTE_STEPS: usize = 100;
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum DragKind {
     Pan,
@@ -24,6 +27,10 @@ pub struct GlobeState {
     pub last_p1: [f32; 3],
     pub last_p2: [f32; 3],
     pub drag: Option<Drag>,
+    /// Pre-computed great-circle slerp points between last_p1 and last_p2.
+    /// Valid indices: `0..=route_steps`. `route_steps == 0` means no route.
+    pub route_points: [[f32; 3]; 101],
+    pub route_steps: usize,
 }
 
 impl Default for GlobeState {
@@ -40,6 +47,8 @@ impl Default for GlobeState {
             last_p1: [0.0; 3],
             last_p2: [0.0; 3],
             drag: None,
+            route_points: [[0.0; 3]; 101],
+            route_steps: 0,
         }
     }
 }

--- a/src/gui/components/globe/tile_manager.rs
+++ b/src/gui/components/globe/tile_manager.rs
@@ -1,5 +1,7 @@
 use eframe::egui::{self, TextureHandle};
+use lru::LruCache;
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 #[cfg(target_arch = "wasm32")]
 use std::sync::Weak;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -7,6 +9,7 @@ use std::sync::{Arc, Mutex};
 
 use super::providers;
 
+/// LOD 3+ tiles are held in an LRU cache of this capacity.
 pub const TILE_CACHE_CAP: usize = 512;
 pub const PENDING_CAP: usize = 512;
 #[cfg(not(target_arch = "wasm32"))]
@@ -14,7 +17,6 @@ pub const NUM_WORKERS: usize = 8;
 const STATS_DECAY_SECS: f64 = 5.0;
 
 pub type TileKey = (u8, u32, u32);
-pub type TileCache = HashMap<TileKey, (TextureHandle, usize)>;
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct TileStats {
@@ -26,14 +28,16 @@ pub struct TileStats {
 }
 
 pub struct TileManagerInner {
-    cache: Mutex<TileCache>,
+    /// LRU cache for LOD >= 3 tiles. Evicts least-recently-used when full.
+    tile_cache: Mutex<LruCache<TileKey, TextureHandle>>,
+    /// Base LODs (0–2) are held here permanently and never evicted.
+    base_cache: Mutex<HashMap<TileKey, TextureHandle>>,
     pending: Mutex<HashSet<TileKey>>,
     #[cfg(target_arch = "wasm32")]
     ctx: egui::Context,
     hits: AtomicUsize,
     misses: AtomicUsize,
     errors: AtomicUsize,
-    access_counter: AtomicUsize,
     last_decay: Mutex<f64>,
     #[cfg(not(target_arch = "wasm32"))]
     request_tx: std::sync::mpsc::Sender<TileKey>,
@@ -50,13 +54,14 @@ impl TileManagerInner {
         let provider: Arc<dyn providers::TileProvider> =
             Arc::new(providers::ArcGisTileProvider::new(http_client));
 
+        let cap = NonZeroUsize::new(TILE_CACHE_CAP).unwrap();
         let manager = Arc::new(Self {
-            cache: Mutex::new(HashMap::new()),
+            tile_cache: Mutex::new(LruCache::new(cap)),
+            base_cache: Mutex::new(HashMap::new()),
             pending: Mutex::new(HashSet::new()),
             hits: AtomicUsize::new(0),
             misses: AtomicUsize::new(0),
             errors: AtomicUsize::new(0),
-            access_counter: AtomicUsize::new(0),
             last_decay: Mutex::new(0.0),
             request_tx: tx,
             provider,
@@ -112,14 +117,15 @@ impl TileManagerInner {
 
     #[cfg(target_arch = "wasm32")]
     pub fn new(ctx: egui::Context) -> Arc<Self> {
+        let cap = NonZeroUsize::new(TILE_CACHE_CAP).unwrap();
         Arc::new(Self {
-            cache: Mutex::new(HashMap::new()),
+            tile_cache: Mutex::new(LruCache::new(cap)),
+            base_cache: Mutex::new(HashMap::new()),
             pending: Mutex::new(HashSet::new()),
             ctx,
             hits: AtomicUsize::new(0),
             misses: AtomicUsize::new(0),
             errors: AtomicUsize::new(0),
-            access_counter: AtomicUsize::new(0),
             last_decay: Mutex::new(0.0),
         })
     }
@@ -137,20 +143,14 @@ impl TileManagerInner {
         let color_image =
             egui::ColorImage::from_rgba_unmultiplied(size, pixels.as_flat_samples().as_slice());
         let tex = ctx.load_texture(format!("tile_{z}_{x}_{y}"), color_image, Default::default());
-        let mut cache = manager.cache.lock().unwrap();
-        if cache.len() >= TILE_CACHE_CAP {
-            // Never evict base LODs — they serve as the always-available fallback.
-            let oldest_key = cache
-                .iter()
-                .filter(|((lod, _, _), _)| *lod >= 3)
-                .min_by_key(|(_, (_, access))| *access)
-                .map(|(&k, _)| k);
-            if let Some(key) = oldest_key {
-                cache.remove(&key);
-            }
+
+        if z < 3 {
+            manager.base_cache.lock().unwrap().insert((z, x, y), tex);
+        } else {
+            // LruCache::put auto-evicts the least-recently-used entry when at capacity.
+            manager.tile_cache.lock().unwrap().put((z, x, y), tex);
         }
-        let access = manager.access_counter.fetch_add(1, Ordering::Relaxed);
-        cache.insert((z, x, y), (tex, access));
+
         ctx.request_repaint();
     }
 }
@@ -165,7 +165,14 @@ impl SharedTileManager {
 
     pub fn trigger_fetch(&self, z: u8, x: u32, y: u32) {
         let key = (z, x, y);
-        if self.0.cache.lock().unwrap().contains_key(&key) {
+
+        // Check the appropriate cache tier without updating LRU order.
+        let already_cached = if z < 3 {
+            self.0.base_cache.lock().unwrap().contains_key(&key)
+        } else {
+            self.0.tile_cache.lock().unwrap().contains(&key)
+        };
+        if already_cached {
             return;
         }
 
@@ -206,30 +213,40 @@ impl SharedTileManager {
         let mut cur_y = y;
 
         loop {
-            let mut cache = self.0.cache.lock().unwrap();
-            if let Some((tex, access)) = cache.get_mut(&(cur_z, cur_x, cur_y)) {
+            let z_diff = z - cur_z;
+            let pow_diff = (1u32 << z_diff) as f32;
+            let dx = (x % (1u32 << z_diff)) as f32;
+            let dy = (y % (1u32 << z_diff)) as f32;
+            let uv = [
+                dx / pow_diff,
+                dy / pow_diff,
+                (dx + 1.0) / pow_diff,
+                (dy + 1.0) / pow_diff,
+            ];
+
+            let tex = if cur_z < 3 {
+                self.0
+                    .base_cache
+                    .lock()
+                    .unwrap()
+                    .get(&(cur_z, cur_x, cur_y))
+                    .cloned()
+            } else {
+                self.0
+                    .tile_cache
+                    .lock()
+                    .unwrap()
+                    .get(&(cur_z, cur_x, cur_y))
+                    .cloned()
+            };
+
+            if let Some(tex) = tex {
                 if cur_z == z {
                     self.0.hits.fetch_add(1, Ordering::Relaxed);
                 } else {
                     self.0.misses.fetch_add(1, Ordering::Relaxed);
                 }
-
-                *access = self.0.access_counter.fetch_add(1, Ordering::Relaxed);
-
-                let z_diff = z - cur_z;
-                let pow_diff = (1u32 << z_diff) as f32;
-                let dx = (x % (1u32 << z_diff)) as f32;
-                let dy = (y % (1u32 << z_diff)) as f32;
-
-                return Some((
-                    tex.clone(),
-                    [
-                        dx / pow_diff,
-                        dy / pow_diff,
-                        (dx + 1.0) / pow_diff,
-                        (dy + 1.0) / pow_diff,
-                    ],
-                ));
+                return Some((tex, uv));
             }
 
             if cur_z == 0 {
@@ -249,7 +266,8 @@ impl SharedTileManager {
             misses: self.0.misses.load(Ordering::Relaxed),
             errors: self.0.errors.load(Ordering::Relaxed),
             pending: self.0.pending.lock().unwrap().len(),
-            cache_size: self.0.cache.lock().unwrap().len(),
+            cache_size: self.0.tile_cache.lock().unwrap().len()
+                + self.0.base_cache.lock().unwrap().len(),
         }
     }
 


### PR DESCRIPTION
…le cache

- Cache Camera::basis() once per frame via CameraBasis; rotate_fast / facing_value_fast replace per-vertex basis() calls (eliminates ~3 sin_cos + cross + 3 normalises per vertex, amortised across all tiles and the ~150 screen_to_world calls in visible_lat_lon_bounds)
- Pre-compute great-circle slerp points in initial_state() and store in GlobeState as a fixed [[f32;3];101] array (preserves Copy); draw_route iterates the cached slice instead of recomputing slerp every frame
- Scale TILE_SUBSTEPS dynamically with LOD (2 at low zoom, 6 at high zoom), reducing vertex count up to 9x for whole-globe views
- Add #[inline] to all Vec3 methods and trait impls
- Replace O(N) LRU eviction in TileManager with lru::LruCache; base LODs (0-2) held in a separate HashMap that is never evicted