### PR TITLE
fix: update locate_in_envelope call for rstar 0.13 API change

### DIFF
--- a/src/modules/airport.rs
+++ b/src/modules/airport.rs
@@ -537,7 +537,7 @@ pub fn get_random_destination_airport_fast<'a, R: Rng + ?Sized>(
 
     // Direct iterator choice - avoids allocating Vec of thousands of candidates
     spatial_airports
-        .locate_in_envelope(&search_envelope)
+        .locate_in_envelope(search_envelope)
         .filter_map(move |spatial_airport| {
             let candidate_cached = &spatial_airport.airport;
             if candidate_cached.inner.ID == departure.inner.ID {


### PR DESCRIPTION
## Summary
- `rstar` 0.13.0 changed `locate_in_envelope` to take `T::Envelope` by value instead of by reference
- Removes the `&` borrow from the call in `src/modules/airport.rs:540`
- Required to allow dependabot PR #462 to merge cleanly

## Test plan
- [ ] `cargo check --features gui` passes with rstar 0.13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)