### PR TITLE
fix: load .env by gating dotenv on the `gui` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,8 @@ impl eframe::App for AirportDatabaseWarning {
 /// Main application startup logic
 #[cfg(all(not(tarpaulin_include), not(target_arch = "wasm32")))]
 fn internal_run_app() -> Result<(), Error> {
-    #[cfg(feature = "dotenvy")]
+    // `dotenvy` is only compiled in via the `gui` feature.
+    #[cfg(feature = "gui")]
     {
         dotenvy::dotenv().ok();
     }


### PR DESCRIPTION
## What

`internal_run_app` guarded its `.env` loading with `#[cfg(feature = "dotenvy")]`:

```rust
#[cfg(feature = "dotenvy")]
{
    dotenvy::dotenv().ok();
}
```

But `Cargo.toml` declares the dependency inside the `gui` feature as `"dep:dotenvy"`. The `dep:` prefix suppresses the implicit feature of the same name, so `feature = "dotenvy"` never evaluated true. The block was **never compiled**, `.env` files were silently ignored, and `dotenvy` was built and linked for nothing.

This gates it on `feature = "gui"` instead — precisely the condition under which the dependency is available.

## Why this fix

`.env` loading is clearly intended here:

- `.env` is listed in `.gitignore`
- the app reads `AVWX_API_KEY` (`src/gui/ui.rs:186`), `FLIGHT_PLANNER_DATA_DIR` (`src/lib.rs:129`), and `LISTEN_ADDR` (`src/server/mod.rs:493`) from the environment

An API key you don't commit is exactly the `.env` use case, so the block was kept and repaired rather than deleted.

Gating on `gui` was chosen over adding an explicit `dotenvy = ["dep:dotenvy"]` feature because `dotenvy` is pulled in *only* by `gui`, so the two conditions are equivalent — and reusing the existing feature avoids new feature machinery, in line with CLAUDE.md's preference for minimal platform-conditional code. No `#[allow(...)]` was used.

## Verification

The dead-code claim was confirmed rather than assumed. Substituting a nonexistent function, `dotenvy::this_symbol_does_not_exist()`, into the block:

| cfg | Result |
|---|---|
| `#[cfg(feature = "dotenvy")]` (old) | **compiles clean** — proving the block was never compiled |
| `#[cfg(feature = "gui")]` (new) | `error[E0425]: cannot find function ... in crate dotenvy` — proving it is now live |

For the runtime half, a temporary in-crate test (integration tests can't see `dotenvy`, as it isn't a dev-dependency) wrote a `.env` into a temp working directory and called the same `dotenvy::dotenv()`:

```
dotenv() -> Ok("...\fp_dotenv_probe\.env")
FP_PROBE_VAR = Ok("picked_up")
FLIGHT_PLANNER_DATA_DIR = Ok("/probe/data")
validate_env_path -> Some("\probe\data")
```

That last call is the very next thing `internal_run_app` does, so the chain `.env` → `env::var` → `validate_env_path` is confirmed end to end. The probe was removed; the diff is only the two lines.

Gate results, all clean:

- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --no-default-features`
- `cargo clippy --no-default-features -- -D warnings`

## Note for the reviewer

`cargo check --no-default-features --features server` fails with 8 errors, but this is **pre-existing and unrelated** — I reproduced an identical error set against a stashed baseline. The `server` feature references `crate::gui::services`, `modules::routes`, and gui-gated `DataOperations` methods, so it has never compiled standalone; CI only builds default and `--no-default-features`, so the gap goes unnoticed. Left alone as out of scope.

A practical consequence worth knowing: a hypothetical `server`-only build would not load `.env`. Since that configuration doesn't currently compile at all, gating on `gui` costs nothing today. If the `server` feature is ever fixed to build standalone, `.env` loading should be revisited alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
